### PR TITLE
Only add `data_vars` to esm catalogs

### DIFF
--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -2,7 +2,7 @@
 
 #PBS -P tm70
 #PBS -l storage=gdata/tm70+gdata/ik11+gdata/cj50+gdata/hh5+gdata/p73+gdata/dk92
-#PBS -q express
+#PBS -q normal
 #PBS -l walltime=02:00:00
 #PBS -l mem=192gb
 #PBS -l ncpus=48

--- a/config/access-cm2.yaml
+++ b/config/access-cm2.yaml
@@ -12,7 +12,7 @@ sources:
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944b
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944c
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944d
-    metadata_yaml: /g/data/tm70/intake/metadata/bx944/metadata.yaml
+    metadata_yaml: /g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944/metadata.yaml
     ensemble: true
     
   - path:
@@ -21,7 +21,7 @@ sources:
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by647b
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by647c
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by647d
-    metadata_yaml: /g/data/tm70/intake/metadata/by647/metadata.yaml
+    metadata_yaml: /g/data/p73/archive/non-CMIP/ACCESS-CM2/by647/metadata.yaml
     ensemble: true
     
   - path:
@@ -30,7 +30,7 @@ sources:
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by473b
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by473c
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by473d
-    metadata_yaml: /g/data/tm70/intake/metadata/by473/metadata.yaml
+    metadata_yaml: /g/data/p73/archive/non-CMIP/ACCESS-CM2/by473/metadata.yaml
     ensemble: true
   
   - path:
@@ -39,7 +39,7 @@ sources:
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by578b
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by578c
       - /g/data/p73/archive/non-CMIP/ACCESS-CM2/by578d
-    metadata_yaml: /g/data/tm70/intake/metadata/by578/metadata.yaml
+    metadata_yaml: /g/data/p73/archive/non-CMIP/ACCESS-CM2/by578/metadata.yaml
     ensemble: true
     
   - path:

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,6 +10,6 @@ dependencies:
   - intake-dataframe-catalog>=0.1.1
   - intake-esm>=2023.4.20
   - jsonschema
-  - netcdf4
   - pooch
   - pre-commit
+  - xarray

--- a/src/access_nri_intake/esmcat/builders.py
+++ b/src/access_nri_intake/esmcat/builders.py
@@ -8,8 +8,8 @@ import re
 import traceback
 from pathlib import Path
 
+import xarray as xr
 from ecgtools.builder import INVALID_ASSET, TRACEBACK, Builder
-from netCDF4 import Dataset
 
 from ..utils import validate_against_schema
 from . import CATALOG_JSONSCHEMA, PATH_COLUMN, VARIABLE_COLUMN
@@ -32,7 +32,7 @@ class BaseBuilder(Builder):
         depth=0,
         exclude_patterns=None,
         include_patterns=None,
-        data_format="netcdf4",
+        data_format="netcdf",
         groupby_attrs=None,
         aggregations=None,
         storage_options=None,
@@ -243,26 +243,26 @@ class AccessOm2Builder(BaseBuilder):
                 [r"\d{4}[-_]\d{2}", r"\d{4}", r"\d{3}", r"\d{2}"], filename
             )
 
-            with Dataset(file, mode="r") as ds:
+            with xr.open_dataset(
+                file,
+                chunks={},
+                decode_cf=False,
+                decode_times=False,
+                decode_coords=False,
+            ) as ds:
                 variable_list = []
                 variable_long_name_list = []
                 variable_standard_name_list = []
                 variable_cell_methods_list = []
-                for var in list(ds.variables):
-                    ncattrs = ds.variables[var].ncattrs()
-                    if "long_name" in ncattrs:
+                for var in ds.data_vars:
+                    attrs = ds[var].attrs
+                    if "long_name" in attrs:
                         variable_list.append(var)
-                        variable_long_name_list.append(
-                            ds.variables[var].getncattr("long_name")
-                        )
-                    if "standard_name" in ncattrs:
-                        variable_standard_name_list.append(
-                            ds.variables[var].getncattr("standard_name")
-                        )
-                    if "cell_methods" in ncattrs:
-                        variable_cell_methods_list.append(
-                            ds.variables[var].getncattr("cell_methods")
-                        )
+                        variable_long_name_list.append(attrs["long_name"])
+                    if "standard_name" in attrs:
+                        variable_standard_name_list.append(attrs["standard_name"])
+                    if "cell_methods" in attrs:
+                        variable_cell_methods_list.append(attrs["cell_methods"])
 
                 start_date, end_date, frequency = get_timeinfo(ds)
 
@@ -355,26 +355,26 @@ class AccessEsm15Builder(BaseBuilder):
             )
             file_id = strip_pattern_rh([exp_id], file_id)
 
-            with Dataset(file, mode="r") as ds:
+            with xr.open_dataset(
+                file,
+                chunks={},
+                decode_cf=False,
+                decode_times=False,
+                decode_coords=False,
+            ) as ds:
                 variable_list = []
                 variable_long_name_list = []
                 variable_standard_name_list = []
                 variable_cell_methods_list = []
-                for var in list(ds.variables):
-                    ncattrs = ds.variables[var].ncattrs()
-                    if "long_name" in ncattrs:
+                for var in ds.data_vars:
+                    attrs = ds[var].attrs
+                    if "long_name" in attrs:
                         variable_list.append(var)
-                        variable_long_name_list.append(
-                            ds.variables[var].getncattr("long_name")
-                        )
-                    if "standard_name" in ncattrs:
-                        variable_standard_name_list.append(
-                            ds.variables[var].getncattr("standard_name")
-                        )
-                    if "cell_methods" in ncattrs:
-                        variable_cell_methods_list.append(
-                            ds.variables[var].getncattr("cell_methods")
-                        )
+                        variable_long_name_list.append(attrs["long_name"])
+                    if "standard_name" in attrs:
+                        variable_standard_name_list.append(attrs["standard_name"])
+                    if "cell_methods" in attrs:
+                        variable_cell_methods_list.append(attrs["cell_methods"])
 
                 start_date, end_date, frequency = get_timeinfo(ds)
 

--- a/src/access_nri_intake/esmcat/builders.py
+++ b/src/access_nri_intake/esmcat/builders.py
@@ -240,7 +240,14 @@ class AccessOm2Builder(BaseBuilder):
             # - iceh.057-daily.nc
             # - oceanbgc-3d-caco3-1-yearly-mean-y_2015.nc
             file_id = strip_pattern_rh(
-                [r"\d{4}[-_]\d{2}", r"\d{4}", r"\d{3}", r"\d{2}"], filename
+                [
+                    r"\d{4}[-_]\d{2}[-_]\d{2}",
+                    r"\d{4}[-_]\d{2}",
+                    r"\d{4}",
+                    r"\d{3}",
+                    r"\d{2}",
+                ],
+                filename,
             )
 
             with xr.open_dataset(

--- a/src/access_nri_intake/esmcat/utils.py
+++ b/src/access_nri_intake/esmcat/utils.py
@@ -16,7 +16,7 @@ def get_timeinfo(ds, time_dim="time"):
 
     Parameters
     ----------
-    ds: :py:class:`netCDF4.Dataset`
+    ds: :py:class:`xarray.Dataset`
         The dataset to parse the time info from
     time_dim: str
         The name of the time dimension
@@ -25,8 +25,8 @@ def get_timeinfo(ds, time_dim="time"):
     if time_dim is None:
         return None
 
-    time_var = ds.variables[time_dim]
-    has_bounds = hasattr(time_var, "bounds") and time_var.bounds in list(ds.variables)
+    time_var = ds[time_dim]
+    has_bounds = hasattr(time_var, "bounds") and time_var.bounds in ds.variables
 
     def _todate(t):
         return cftime.num2date(t, time_var.units, calendar=time_var.calendar)


### PR DESCRIPTION
Here we revert back to using xarray in the esm parsers and include as variables only `data_vars`.

Closes #63 