### PR TITLE
Release v0.0.6

### DIFF
--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 #PBS -P tm70
-#PBS -l storage=gdata/tm70+gdata/ik11+gdata/cj50+gdata/hh5+gdata/p73+gdata/dk92
+#PBS -l storage=gdata/tm70+gdata/xp65+gdata/ik11+gdata/cj50+gdata/hh5+gdata/p73+gdata/dk92
 #PBS -q normal
 #PBS -l walltime=02:00:00
 #PBS -l mem=192gb
@@ -26,7 +26,7 @@ fi
 
 conda activate access-nri-intake-dev
 
-OUTPUT_BASE_PATH=/g/data/tm70/intake
+OUTPUT_BASE_PATH=/g/data/xp65/public/apps/access-nri-intake-catalog
 CONFIG_DIR=/g/data/tm70/ds0092/projects/access-nri-intake-catalog/config
 CONFIGS=( cmip5.yaml cmip6.yaml access-om2.yaml access-cm2.yaml access-esm1-5.yaml ) # erai.yaml
 

--- a/src/access_nri_intake/cat/catalog.yaml
+++ b/src/access_nri_intake/cat/catalog.yaml
@@ -8,15 +8,15 @@ sources:
       - variable
       mode: r
       name_column: name
-      path: /g/data/tm70/intake/{{version}}/metacatalog.csv
+      path: /g/data/xp65/public/apps/access-nri-intake-catalog/{{version}}/metacatalog.csv
       yaml_column: yaml
     description: ACCESS-NRI intake catalog
     driver: intake_dataframe_catalog.core.DfFileCatalog
     metadata:
-      storage: gdata/cj50+gdata/dk92+gdata/ik11+gdata/p73
+      storage: gdata/cj50+gdata/p73+gdata/ik11+gdata/dk92
       version: '{{version}}'
     parameters:
       version:
-        default: v0.0.5.post1
+        default: v0.0.6
         description: Catalog version
         type: str


### PR DESCRIPTION
New build of the catalog to `xp65` for use in MED-managed environment