### PR TITLE
Fix small typos in tutorials

### DIFF
--- a/docs/usage/chunking.ipynb
+++ b/docs/usage/chunking.ipynb
@@ -200,7 +200,7 @@
    "metadata": {},
    "source": [
     "```{hint}\n",
-    "   It is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text ouput by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
+    "   If your actually running this tutorial, it is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text output by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
     "```"
    ]
   },

--- a/docs/usage/chunking.ipynb
+++ b/docs/usage/chunking.ipynb
@@ -200,7 +200,7 @@
    "metadata": {},
    "source": [
     "```{hint}\n",
-    "   If your actually running this tutorial, it is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text output by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
+    "   If you're actually running this tutorial, it is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text output by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
     "```"
    ]
   },

--- a/docs/usage/quickstart.ipynb
+++ b/docs/usage/quickstart.ipynb
@@ -1679,7 +1679,7 @@
    "metadata": {},
    "source": [
     "```{hint}\n",
-    "   It is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text ouput by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
+    "   If your actually running this tutorial, it is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text output by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
     "```"
    ]
   },

--- a/docs/usage/quickstart.ipynb
+++ b/docs/usage/quickstart.ipynb
@@ -1679,7 +1679,7 @@
    "metadata": {},
    "source": [
     "```{hint}\n",
-    "   If your actually running this tutorial, it is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text output by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
+    "   If you're actually running this tutorial, it is very helpful to monitor the dask dashboard when working with dask. Click on the dask icon on the far left of the screen (three orange and red squares) and enter the text output by the previous cell in the search bar. Each of the different orange panels is a different dashboard that you can use to monitor what dask is doing. If you don't know which to choose, the \"Task Stream\", \"Progress\", \"CPU\" and \"Workers Memory\" diagnostics are a good start. Click on these, and drag the windows to where ever you want them in your JupyterLab.\n",
     "```"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,6 @@ requires = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.pytest.ini_options]
-addopts = "--cov=./src --cov-report=xml"
-
 [tool.setuptools.package-data]
 access_nri_intake = ["data/catalog.yaml"]
 
@@ -54,6 +51,14 @@ versionfile_source = "src/access_nri_intake/_version.py"
 versionfile_build = "access_nri_intake/_version.py"
 tag_prefix = "v"
 parentdir_prefix = "access-nri-intake-"
+
+[tool.pytest.ini_options]
+addopts = "--cov=./src --cov-report=xml"
+
+[tool.coverage.run]
+omit = [
+    "src/access_nri_intake/_version.py",
+]
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
I noticed a couple of minor typos in the hint for how to use the dask dashboard. These are fixed here