### PR TITLE
Move to trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,8 @@ jobs:
     name: build and deploy to PyPI
     if: github.repository == 'ACCESS-NRI/access-nri-intake-catalog' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: "ubuntu-latest"
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout source
@@ -28,9 +30,6 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
 
   conda:
     name: build and deploy to conda


### PR DESCRIPTION
This PR changes the PyPI publish workflow to use OpenID Connect over a repo secret.