### PR TITLE
Update for pydantic v2 compatibility

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,10 +21,10 @@ requirements:
   run:
     - python >=3.9
     - cftime
-    - ecgtools>=2022.10.07
+    - ecgtools>=2023.7.7
     - intake>=0.7.0
     - intake-dataframe-catalog>=0.2.2
-    - intake-esm>=2023.4.20
+    - intake-esm>=2023.7.7
     - jsonschema
     - pooch
     - xarray

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=3.9
     - cftime
-    - ecgtools>=2023.7.7
+    - ecgtools>=2023.7.13
     - intake>=0.7.0
     - intake-dataframe-catalog>=0.2.2
     - intake-esm>=2023.7.7

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.10
   - cftime
-  - ecgtools>=2023.7.7
+  - ecgtools>=2023.7.13
   - intake-dataframe-catalog>=0.2.2
   - intake-esm>=2023.7.7
   - jsonschema

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -6,14 +6,12 @@ channels:
 dependencies:
   - python==3.10
   - cftime
-  - ecgtools>=2022.10.07
-  - fsspec<=2023.5.0 # see https://github.com/ncar-xdev/ecgtools/issues/160
+  - ecgtools>=2023.7.??
   - intake-dataframe-catalog>=0.1.1
-  - intake-esm>=2023.4.20
+  - intake-esm>=2023.7.??
   - jsonschema
   - pooch
   - pre-commit
-  - pydantic<2.0 # see https://github.com/intake/intake-esm/issues/617, https://github.com/ncar-xdev/ecgtools/issues    /161
   - pytest
   - xarray
   - pip

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -6,9 +6,9 @@ channels:
 dependencies:
   - python==3.10
   - cftime
-  - ecgtools>=2023.7.??
-  - intake-dataframe-catalog>=0.1.1
-  - intake-esm>=2023.7.??
+  - ecgtools>=2023.7.7
+  - intake-dataframe-catalog>=0.2.2
+  - intake-esm>=2023.7.7
   - jsonschema
   - pooch
   - pre-commit

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -6,9 +6,9 @@ channels:
 dependencies:
   - python==3.11
   - cftime
-  - ecgtools>=2023.7.??
-  - intake-dataframe-catalog>=0.1.1
-  - intake-esm>=2023.7.??
+  - ecgtools>=2023.7.7
+  - intake-dataframe-catalog>=0.2.2
+  - intake-esm>=2023.7.7
   - jsonschema
   - pooch
   - pre-commit

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -6,14 +6,12 @@ channels:
 dependencies:
   - python==3.11
   - cftime
-  - ecgtools>=2022.10.07
-  - fsspec<=2023.5.0 # see https://github.com/ncar-xdev/ecgtools/issues/160
+  - ecgtools>=2023.7.??
   - intake-dataframe-catalog>=0.1.1
-  - intake-esm>=2023.4.20
+  - intake-esm>=2023.7.??
   - jsonschema
   - pooch
   - pre-commit
-  - pydantic<2.0 # see https://github.com/intake/intake-esm/issues/617, https://github.com/ncar-xdev/ecgtools/issues/161
   - pytest
   - xarray
   - pip

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.11
   - cftime
-  - ecgtools>=2023.7.7
+  - ecgtools>=2023.7.13
   - intake-dataframe-catalog>=0.2.2
   - intake-esm>=2023.7.7
   - jsonschema

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.9.2 # see https://github.com/dask/distributed/issues/7956
   - cftime
-  - ecgtools>=2023.7.7
+  - ecgtools>=2023.7.13
   - intake-dataframe-catalog>=0.2.2
   - intake-esm>=2023.7.7
   - jsonschema

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -6,9 +6,9 @@ channels:
 dependencies:
   - python>=3.9.2 # see https://github.com/dask/distributed/issues/7956
   - cftime
-  - ecgtools>=2023.7.??
-  - intake-dataframe-catalog>=0.1.1
-  - intake-esm>=2023.7.??
+  - ecgtools>=2023.7.7
+  - intake-dataframe-catalog>=0.2.2
+  - intake-esm>=2023.7.7
   - jsonschema
   - pooch
   - pre-commit

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -6,14 +6,12 @@ channels:
 dependencies:
   - python>=3.9.2 # see https://github.com/dask/distributed/issues/7956
   - cftime
-  - ecgtools>=2022.10.07
-  - fsspec<=2023.5.0 # see https://github.com/ncar-xdev/ecgtools/issues/160
+  - ecgtools>=2023.7.??
   - intake-dataframe-catalog>=0.1.1
-  - intake-esm>=2023.4.20
+  - intake-esm>=2023.7.??
   - jsonschema
   - pooch
   - pre-commit
-  - pydantic<2.0 # see https://github.com/intake/intake-esm/issues/617, https://github.com/ncar-xdev/ecgtools/issues    /161
   - pytest
   - xarray
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "cftime",
-    "ecgtools>=2023.7.7",
+    "ecgtools>=2023.7.13",
     "intake>=0.7.0",
     "intake-dataframe-catalog>=0.2.2",
     "intake-esm>=2023.7.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ classifiers = [
 ]
 dependencies = [
     "cftime",
-    "ecgtools>=2022.10.07",
+    "ecgtools>=2023.7.??",
     "intake>=0.7.0",
     "intake-dataframe-catalog>=0.2.2",
-    "intake-esm>=2023.4.20",
+    "intake-esm>=2023.7.??",
     "jsonschema",
     "pooch",
     "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ classifiers = [
 ]
 dependencies = [
     "cftime",
-    "ecgtools>=2023.7.??",
+    "ecgtools>=2023.7.7",
     "intake>=0.7.0",
     "intake-dataframe-catalog>=0.2.2",
-    "intake-esm>=2023.7.??",
+    "intake-esm>=2023.7.7",
     "jsonschema",
     "pooch",
     "xarray",

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -76,7 +76,7 @@ class BaseBuilder(Builder):
         self.storage_options = storage_options
         self.joblib_parallel_kwargs = joblib_parallel_kwargs
 
-        super().__post_init_post_parse__()
+        super().__post_init__()
 
     def _parse(self):
         super().parse(parsing_func=self.parser)


### PR DESCRIPTION
This PR updates dependencies to versions compatible with pydantic v2. Note the new dependency versions haven't actually been released yet, but they should be released this month so for now I've just put placeholders for version numbers (this is why the checks are failing).

Closes #101, Closes #102