### PR TITLE
Update schema to allow version strings

### DIFF
--- a/bin/create_metadata_yaml_template.py
+++ b/bin/create_metadata_yaml_template.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright 2023 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -5,7 +7,7 @@ import argparse
 
 import yaml
 
-from access_nri_intake.catalog import METADATA_JSONSCHEMA
+from access_nri_intake.catalog import EXP_JSONSCHEMA
 
 
 def main():
@@ -14,8 +16,8 @@ def main():
     )
 
     template = {}
-    for name, descr in METADATA_JSONSCHEMA["properties"].items():
-        if name in METADATA_JSONSCHEMA["required"]:
+    for name, descr in EXP_JSONSCHEMA["properties"].items():
+        if name in EXP_JSONSCHEMA["required"]:
             description = f"<REQUIRED {descr['description']}>"
         else:
             description = f"<{descr['description']}>"

--- a/bin/validate_metadata_yaml.py
+++ b/bin/validate_metadata_yaml.py
@@ -1,11 +1,13 @@
+#!/usr/bin/env python
+
 # Copyright 2023 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import glob
 
-from access_nri_intake.catalog import METADATA_JSONSCHEMA
-from access_nri_intake.utils import load_metadata_yaml, validate_against_schema
+from access_nri_intake.catalog import EXP_JSONSCHEMA
+from access_nri_intake.utils import load_metadata_yaml
 
 
 def main():
@@ -23,12 +25,8 @@ def main():
     file = args.file
 
     for f in glob.glob(file):
-        instance = load_metadata_yaml(f)
-
         print(f"Validating {f}... ", end="")
-
-        validate_against_schema(instance, METADATA_JSONSCHEMA)
-
+        load_metadata_yaml(f, EXP_JSONSCHEMA)
         print("success")
 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,7 @@ variable:
 - <The variable(s) included in the experiment (string)>
 nominal_resolution:
 - <The nominal resolution(s) of model(s) used in the experiment (string)>
-version: <The version of the experiment (number)>
+version: <The version of the experiment (number, string)>
 contact: <Contact name for the experiment (string)>
 email: <Email address of the contact for the experiment (string)>
 created: <Initial creation date of experiment (string)>

--- a/src/access_nri_intake/catalog/__init__.py
+++ b/src/access_nri_intake/catalog/__init__.py
@@ -18,8 +18,8 @@ YAML_COLUMN = "yaml"
 NAME_COLUMN = "name"
 TRANSLATOR_GROUPBY_COLUMNS = ["model", "realm", "frequency"]
 
-SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/9170a894c22123c90a703104d6a53c32cf975645/experiment_asset.json"
-SCHEMA_HASH = "c4f4a546110a6f761f934ddb50b3ff63031a70f08233c1b5109a5ce80b078a41"
+SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/36abe2fe28eb2853a54f41c5eedfd964617d9d68/experiment_asset.json"
+SCHEMA_HASH = "60d439a9ad5602464c7dad54072ac276d1fae3634f9524edcc82073a5a92616a"
 
 EXP_JSONSCHEMA, CATALOG_JSONSCHEMA = get_jsonschema(
     url=SCHEMA_URL, known_hash=SCHEMA_HASH, required=CORE_COLUMNS

--- a/src/access_nri_intake/catalog/__init__.py
+++ b/src/access_nri_intake/catalog/__init__.py
@@ -18,8 +18,8 @@ YAML_COLUMN = "yaml"
 NAME_COLUMN = "name"
 TRANSLATOR_GROUPBY_COLUMNS = ["model", "realm", "frequency"]
 
-SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/d4da77a0e627775c11ba394c0a3f72a2c654971c/experiment_asset.json"
-SCHEMA_HASH = "b18cf5bdd06a6f5bcdc71dfc80f7336c63eb49f6d6f75c2cd3371e59eee5488b"
+SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/9170a894c22123c90a703104d6a53c32cf975645/experiment_asset.json"
+SCHEMA_HASH = "c4f4a546110a6f761f934ddb50b3ff63031a70f08233c1b5109a5ce80b078a41"
 
 EXP_JSONSCHEMA, CATALOG_JSONSCHEMA = get_jsonschema(
     url=SCHEMA_URL, known_hash=SCHEMA_HASH, required=CORE_COLUMNS


### PR DESCRIPTION
Use latest version of experiment schema, which allows `version` to be a string (not just a number)