### PR TITLE
Add Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,7 +6,7 @@
             "name": "Squire, Dougal"
         },
         {
-            "orcid": "",
+            "orcid": "0009-0002-9081-4106",
             "affiliation": "ACCESS-NRI",
             "name": "Steketee, Anton"
         },
@@ -16,7 +16,7 @@
             "name": "Tetley, Michael"
         },
         {
-            "orcid": "",
+            "orcid": "0000-0002-4481-4896",
             "affiliation": "ACCESS-NRI",
             "name": "Heerdegen, Aidan"
         },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,19 +6,24 @@
             "name": "Squire, Dougal"
         },
         {
+            "orcid": "",
+            "affiliation": "ACCESS-NRI",
+            "name": "Steketee, Anton"
+        },
+        {
             "orcid": "0000-0002-2320-4239",
             "affiliation": "ACCESS-NRI",
             "name": "Tetley, Michael"
         },
         {
+            "orcid": "",
+            "affiliation": "ACCESS-NRI",
+            "name": "Heerdegen, Aidan"
+        },
+        {
             "orcid": "0000-0003-3891-5444",
             "affiliation": "ACCESS-NRI",
             "name": "Beucher, Romain"
-        },
-        {
-            "orcid": "",
-            "affiliation": "ACCESS-NRI",
-            "name": "Proft, Max"           
         }
     ],
 


### PR DESCRIPTION
I am adding some metadata for Zenodo on all the MED-related packages.
Please let me know if you are happy to be included or if you think I missed someone.
Also, you can change the order.

We don't have clear directives on who we should add or not. My views are
- Main code contributors should go first 
- People who have participated indirectly in testing, and discussion during the development phase (@headmetal)
- Maintainers
- Other small contributors (bug fixes)

I tend to be quite open as I think the work environment often influences how we do things, but that is my personal opinion.

@aidanheerdegen, @anton-seaice can you please add your ORCID?

Thanks!