### PR TITLE
Assign ww3 data to wave realm in access-om3 builder

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -221,12 +221,8 @@ class AccessOm2Builder(BaseBuilder):
     @staticmethod
     def parser(file):
         try:
-            match_groups = re.match(
-                r".*/([^/]*)/([^/]*)/output\d+/([^/]*)/.*\.nc", file
-            ).groups()
-            # configuration = match_groups[0]
-            # exp_id = match_groups[1]
-            realm = match_groups[2]
+            match_groups = re.match(r".*/output\d+/([^/]*)/.*\.nc", file).groups()
+            realm = match_groups[0]
 
             if realm == "ice":
                 realm = "seaIce"

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -323,8 +323,10 @@ class AccessOm3Builder(BaseBuilder):
                 variable_units_list,
             ) = parse_access_ncfile(file)
 
-            if ("mom6" in filename) or ("ww3" in filename):
+            if "mom6" in filename:
                 realm = "ocean"
+            elif "ww3" in filename:
+                realm = "wave"
             elif "cice" in filename:
                 realm = "seaIce"
             else:

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -11,9 +11,9 @@ from access_nri_intake.source import CORE_COLUMNS, builders
 
 
 @pytest.mark.parametrize(
-    "basedirs, builder, kwargs, num_assets, num_valid_assets, num_datasets",
+    "basedirs, builder, kwargs, num_assets, num_valid_assets, num_datasets, realms",
     [
-        (["access-om2"], "AccessOm2Builder", {}, 12, 12, 6),
+        (["access-om2"], "AccessOm2Builder", {}, 12, 12, 6, ["ocean", "seaIce"]),
         (
             ["access-cm2/by578", "access-cm2/by578a"],
             "AccessCm2Builder",
@@ -21,9 +21,26 @@ from access_nri_intake.source import CORE_COLUMNS, builders
             18,
             14,
             7,
+            ["atmos", "ocean", "seaIce"],
         ),
-        (["access-esm1-5"], "AccessEsm15Builder", {"ensemble": False}, 11, 11, 11),
-        (["access-om3"], "AccessOm3Builder", {}, 12, 12, 6),
+        (
+            ["access-esm1-5"],
+            "AccessEsm15Builder",
+            {"ensemble": False},
+            11,
+            11,
+            11,
+            ["atmos", "ocean", "seaIce"],
+        ),
+        (
+            ["access-om3"],
+            "AccessOm3Builder",
+            {},
+            12,
+            12,
+            6,
+            ["ocean", "wave", "seaIce"],
+        ),
     ],
 )
 def test_builder_build(
@@ -35,6 +52,7 @@ def test_builder_build(
     num_assets,
     num_valid_assets,
     num_datasets,
+    realms,
 ):
     """
     Test the various steps of the build process
@@ -60,6 +78,7 @@ def test_builder_build(
     )
     assert len(cat.df) == num_valid_assets
     assert len(cat) == num_datasets
+    assert sorted(cat.unique()["realm"]) == sorted(realms)
 
 
 def test_builder_columns_with_iterables(test_data):


### PR DESCRIPTION
"wave" is [now](https://github.com/ACCESS-NRI/access-nri-intake-catalog/pull/161) an acceptable realm in the schema. This PR assigns WW3 data to the wave realm in the `AccessOm3Builder`