### PR TITLE
Replace deprecated pandas `applymap` with `map`

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - ecgtools>=2023.7.13
     - intake==0.7.0
     - intake-dataframe-catalog>=0.2.3
-    - intake-esm>=2023.10.27
+    - intake-esm>=2023.11.10
     - jsonschema
     - pooch
     - xarray

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -9,7 +9,7 @@ dependencies:
   - ecgtools>=2023.7.13
   - intake==0.7.0
   - intake-dataframe-catalog>=0.2.3
-  - intake-esm>=2023.10.27
+  - intake-esm>=2023.11.10
   - jsonschema
   - pooch
   - pre-commit

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -9,7 +9,7 @@ dependencies:
   - ecgtools>=2023.7.13
   - intake==0.7.0
   - intake-dataframe-catalog>=0.2.3
-  - intake-esm>=2023.10.27
+  - intake-esm>=2023.11.10
   - jsonschema
   - pooch
   - pre-commit

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -9,7 +9,7 @@ dependencies:
   - ecgtools>=2023.7.13
   - intake==0.7.0
   - intake-dataframe-catalog>=0.2.3
-  - intake-esm>=2023.10.27
+  - intake-esm>=2023.11.10
   - jsonschema
   - pooch
   - pre-commit

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ autoapi_options = [
     "inherited-members",
     "show-inheritance",
     "show-module-summary",
+    "undoc-members",  # workaround for https://github.com/readthedocs/sphinx-autoapi/issues/448
 ]
 
 templates_path = ["_templates"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ecgtools>=2023.7.13",
     "intake==0.7.0",
     "intake-dataframe-catalog>=0.2.3",
-    "intake-esm>=2023.10.27",
+    "intake-esm>=2023.11.10",
     "jsonschema",
     "pooch",
     "xarray",

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -163,7 +163,7 @@ class BaseBuilder(Builder):
             return set()
         has_iterables = (
             self.df.sample(20, replace=True)
-            .applymap(type)
+            .map(type)
             .isin([list, tuple, set])
             .any()
             .to_dict()

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -146,10 +146,7 @@ def test_builder_columns_with_iterables(test_data):
     assert sorted(list(builder.columns_with_iterables)) == sorted(
         [
             col
-            for col, val in builder.df.applymap(type)
-            .isin([list, tuple, set])
-            .any()
-            .items()
+            for col, val in builder.df.map(type).isin([list, tuple, set]).any().items()
             if val
         ]
     )


### PR DESCRIPTION
Very simple PR to remove use of the deprecated `applymap` method. Closes #172

ADDED: Also includes a workaround for a new issue in sphinx-autoapi