### PR TITLE
Update xp65 environment

### DIFF
--- a/docs/usage/how.rst
+++ b/docs/usage/how.rst
@@ -107,4 +107,4 @@ data it references are available from your session. In particular:
   JupyterLab session using the "Advanced options" to set the "Module directories" to 
   :code:`/g/data/hh5/public/modules` and "Modules" to :code:`conda/analysis3-unstable`. Similarly, to use 
   the :code:`xp65` environment, set "Module directories" to :code:`/g/data/xp65/public/modules` and 
-  "Modules" to :code:`conda/are`.
+  "Modules" to :code:`conda/access-med`.


### PR DESCRIPTION
Using `conda/are` within the xp65 project allows the user to import the intake catalog in ARE, whereas `conda/access-med` no longer works.  To reflect this change, `conda/are` has been replaced with `conda/access-med` in the 'How do I use it?' section of the docs. 
Fixes issue #182 