### PR TITLE
Update metadata locations for existing CMIP5 and CMIP6 experiments

### DIFF
--- a/config/cmip5.yaml
+++ b/config/cmip5.yaml
@@ -4,10 +4,10 @@ translator: Cmip5Translator
 
 sources:
 
-  - metadata_yaml: /g/data/tm70/intake/metadata/cmip5_al33/metadata.yaml
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/cmip5_al33/metadata.yaml
     path:
       - /g/data/dk92/catalog/v2/esm/cmip5-al33/catalog.json
     
-  - metadata_yaml: /g/data/tm70/intake/metadata/cmip5_rr3/metadata.yaml
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/cmip5_rr3/metadata.yaml
     path:
       - /g/data/dk92/catalog/v2/esm/cmip5-rr3/catalog.json

--- a/config/cmip6.yaml
+++ b/config/cmip6.yaml
@@ -4,10 +4,10 @@ translator: Cmip6Translator
 
 sources:
 
-  - metadata_yaml: /g/data/tm70/intake/metadata/cmip6_fs38/metadata.yaml
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/cmip6_fs38/metadata.yaml
     path:
       - /g/data/dk92/catalog/v2/esm/cmip6-fs38/catalog.json
     
-  - metadata_yaml: /g/data/tm70/intake/metadata/cmip6_oi10/metadata.yaml
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/cmip6_oi10/metadata.yaml
     path:
       - /g/data/dk92/catalog/v2/esm/cmip6-oi10/catalog.json

--- a/config/experiments/cmip5-al33/metadata.yaml
+++ b/config/experiments/cmip5-al33/metadata.yaml
@@ -1,0 +1,52 @@
+# Metadata recovered 2024-09-25
+# {'contact': 'NCI',
+#  'created': None,
+#  'description': 'Replicated CMIP5-era datasets catalogued by NCI',
+#  'email': 'help@nci.org.au',
+#  'experiment_uuid': '658c95cc-c299-450c-82a1-b2b2308f7c6e',
+#  'keywords': ['cmip'],
+#  'license': None,
+#  'long_description': 'All CMIP5-era replicated data contained under the project al33.  All file versions present are in the listing. Maintained By: NCI Contact: help@nci.org.au References: https://pcmdi.llnl.gov/mips/cmip5/',
+#  'model': ['CMIP5'],
+#  'name': 'cmip5_al33',
+#  'nominal_resolution': [None],
+#  'notes': 'null',
+#  'parent_experiment': None,
+#  'reference': None,
+#  'related_experiments': [None],
+#  'url': 'https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f9489_5106_5649_5038',
+#  'version': None,
+#  'catalog_dir': ''}
+
+name: cmip5_al33
+experiment_uuid: 658c95cc-c299-450c-82a1-b2b2308f7c6e
+description: Replicated CMIP5-era datasets catalogued by NCI
+long_description: >-
+  All CMIP5-era replicated data contained under the project al33.
+  All file versions present are in the listing. 
+  Maintained By: NCI 
+  Contact: help@nci.org.au 
+  References: https://pcmdi.llnl.gov/mips/cmip5/
+model:
+- CMIP5
+realm:
+- atmos
+- ocean
+- aerosol
+- ocnBgchem
+- land
+- seaIce
+- landIce
+- landonly
+version: 
+contact: NCI
+email: help@nci.org.au 
+created: 
+reference: 
+license: 
+url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f9489_5106_5649_5038
+parent_experiment: 
+related_experiments:
+- 
+notes: 
+- cmip

--- a/config/experiments/cmip5-rr3/metadata.yaml
+++ b/config/experiments/cmip5-rr3/metadata.yaml
@@ -1,0 +1,60 @@
+# Metadata recovered 2024-09-25
+# {'contact': 'NCI',
+#  'created': None,
+#  'description': 'Australian CMIP5-era datasets catalogued by NCI',
+#  'email': 'help@nci.org.au',
+#  'experiment_uuid': '473d0c44-ab66-458c-b32e-1e1774175853',
+#  'keywords': ['cmip'],
+#  'license': None,
+#  'long_description': 'All CMIP5-era Australian published data contained under the project rr3.  All file versions present are in the listing. Maintained By: NCI Contact: help@nci.org.au References: https://pcmdi.llnl.gov/mips/cmip5/',
+#  'model': ['CMIP5'],
+#  'name': 'cmip5_rr3',
+#  'nominal_resolution': [None],
+#  'notes': 'null',
+#  'parent_experiment': None,
+#  'reference': None,
+#  'related_experiments': [None],
+#  'url': 'https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f7448_2157_9857_1076',
+#  'version': None,
+#  'catalog_dir': ''}
+# 
+name: cmip5_rr3
+experiment_uuid: 473d0c44-ab66-458c-b32e-1e1774175853
+description: Australian CMIP5-era datasets catalogued by NCI
+long_description: >-
+  All CMIP5-era Australian published data contained under the project rr3.
+  All file versions present are in the listing. 
+  Maintained By: NCI 
+  Contact: help@nci.org.au 
+  References: https://pcmdi.llnl.gov/mips/cmip5/
+realm:
+- atmos
+- ocean
+- seaIce
+- landIce
+- land
+- aerosol
+model:
+- CMIP5
+frequency:
+- 1hr
+- mon
+- day
+- 6hr
+- sem
+- 3hr
+- fx
+nominal_resolution:
+-
+version: 
+contact: NCI
+email: help@nci.org.au
+created: 
+reference: 
+license: 
+url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f7448_2157_9857_1076
+related_experiments:
+- 
+notes: 
+keywords:
+- cmip

--- a/config/experiments/cmip6-fs38/metadata.yaml
+++ b/config/experiments/cmip6-fs38/metadata.yaml
@@ -1,0 +1,54 @@
+name: cmip6_fs38
+experiment_uuid: dfdeb421-5c56-4d58-a0b2-04b717e5cff7
+description: Australian CMIP6-era datasets catalogued by NCI
+long_description: >-
+  All CMIP6-era Australian published data contained under the project fs38.
+  All file versions present are in the listing.
+  Maintained By: NCI
+  Contact: help@nci.org.au
+  References: https://pcmdi.llnl.gov/CMIP6/
+model:
+- CMIP6
+realm:
+- ocnBgchem
+- land
+- ocean
+- atmos
+- landIce
+- seaIce
+- aerosol
+nominal_resolution:
+- 
+version: 
+contact: NCI
+email: help@nci.org.au
+created: 
+reference: 
+license:
+url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f3154_9976_7262_7595
+parent_experiment: 
+related_experiments:
+- 
+notes: 
+keywords:
+- cmip
+
+# Metadata recovered 2024-09-25
+# {'contact': 'NCI',
+#  'created': None,
+#  'description': 'Australian CMIP6-era datasets catalogued by NCI',
+#  'email': 'help@nci.org.au',
+#  'experiment_uuid': 'dfdeb421-5c56-4d58-a0b2-04b717e5cff7',
+#  'keywords': ['cmip'],
+#  'license': None,
+#  'long_description': 'All CMIP6-era Australian published data contained under the project fs38.  All file versions present are in the listing. Maintained By: NCI Contact: help@nci.org.au References: https://pcmdi.llnl.gov/CMIP6/',
+#  'model': ['CMIP6'],
+#  'name': 'cmip6_fs38',
+#  'nominal_resolution': [None],
+#  'notes': 'null',
+#  'parent_experiment': None,
+#  'reference': None,
+#  'related_experiments': [None],
+#  'url': 'https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f3154_9976_7262_7595',
+#  'version': None,
+#  'catalog_dir': ''}

--- a/config/experiments/cmip6-oi10/metadata.yaml
+++ b/config/experiments/cmip6-oi10/metadata.yaml
@@ -1,0 +1,61 @@
+name: cmip6_oi10
+experiment_uuid: b05038ca-8c78-4ca6-a914-ae33dd9abffe
+description: Replicated CMIP6-era datasets catalogued by NCI
+long_description: >-
+  All CMIP6-era replicated data contained under the project oi10.
+  All file versions present are in the listing. 
+  Maintained By: NCI 
+  Contact: help@nci.org.au 
+  References: https://pcmdi.llnl.gov/CMIP6/
+model:
+- CMIP6
+realm:
+- atmos
+- ocean
+- land
+- seaIce
+- aerosol
+- landIce
+- ocnBgchem
+- seaIce ocean
+- atmos land
+- ocnBgChem
+- landIce land
+- seaice
+- ocean seaIce
+- atmos atmosChem
+nominal_resolution:
+- 
+version: 
+contact: NCI
+email: help@nci.org.au
+created: 
+reference:
+license: 
+url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f5194_5909_8003_9216
+parent_experiment:
+related_experiments:
+- 
+notes: 
+keywords:
+- cmip
+
+# Metadata recovered 2024-09-25
+# {'contact': 'NCI',
+#  'created': None,
+#  'description': 'Replicated CMIP6-era datasets catalogued by NCI',
+#  'email': 'help@nci.org.au',
+#  'experiment_uuid': 'b05038ca-8c78-4ca6-a914-ae33dd9abffe',
+#  'keywords': ['cmip'],
+#  'license': None,
+#  'long_description': 'All CMIP6-era replicated data contained under the project oi10.  All file versions present are in the listing. Maintained By: NCI Contact: help@nci.org.au References: https://pcmdi.llnl.gov/CMIP6/',
+#  'model': ['CMIP6'],
+#  'name': 'cmip6_oi10',
+#  'nominal_resolution': [None],
+#  'notes': 'null',
+#  'parent_experiment': None,
+#  'reference': None,
+#  'related_experiments': [None],
+#  'url': 'https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f5194_5909_8003_9216',
+#  'version': None,
+#  'catalog_dir': ''}


### PR DESCRIPTION
Closes #200 .

New `metadata.yaml` have been placed in `/g/data/xp65/admin/intake/metadata/`, and referenced in the catalog `config` YAMLs.