### PR TITLE
226 editable install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install source
         shell: bash -l {0}
-        run: python -m pip install -e .
+        run: python -m pip install .
 
       - name: List installed packages
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: python -m pytest -s .
+        run: coverage run -m --source=access_nri_intake pytest
+      
+      - name: Generate coverage report
+        shell: bash -l {0}
+        run: coverage xml
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,10 @@ versionfile_build = "access_nri_intake/_version.py"
 tag_prefix = "v"
 parentdir_prefix = "access-nri-intake-"
 
-[tool.pytest.ini_options]
-addopts = "--cov=./src --cov-report=xml"
-
 [tool.coverage.run]
 omit = [
-    "src/access_nri_intake/_version.py",
-    "src/access_nri_intake/data/__init__.py",
+    "*/_version.py",
+    "*/data/__init__.py",
 ]
 
 [tool.ruff]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from access_nri_intake.cli import (
     MetadataCheckError,
     _check_build_args,
     build,
+    metadata_template,
     metadata_validate,
 )
 
@@ -163,3 +164,7 @@ def test_metadata_validate_no_file(mockargs):
     with pytest.raises(FileNotFoundError) as excinfo:
         metadata_validate()
     assert "No such file(s)" in str(excinfo.value)
+
+
+def test_metadata_template():
+    metadata_template()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,14 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from pathlib import Path
 
+import access_nri_intake
 from access_nri_intake.utils import get_catalog_fp
 
 
 def test_get_catalog_fp():
-    _oneup = os.path.abspath(os.path.dirname("../"))
-    assert str(get_catalog_fp()) == str(
-        os.path.join(
-            _oneup, "access-nri-intake-catalog/src/access_nri_intake/data/catalog.yaml"
-        )
-    )
+    """
+    Check that we're getting the correct path to the catalog.yaml file. We need
+    to ensure that this works both in editable & non-editable installs.
+    """
+    INSTALL_DIR = Path(access_nri_intake.__file__).parent
+    expected_path = os.path.join(INSTALL_DIR, "data/catalog.yaml")
+
+    catalog_fullpath = get_catalog_fp()
+
+    assert str(catalog_fullpath) == expected_path


### PR DESCRIPTION
- Fixed issue where `tests/test_data::test_get_catalog_fp()` would only work when performed using an editable installation.

Closes #226 