### PR TITLE
Intake Take2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "cftime",
     "ecgtools>=2023.7.13",
-    "intake==0.7.0",
+    "intake>=0.7.0",
     "intake-dataframe-catalog>=0.2.4",
     "intake-esm>=2023.11.10",
     "jsonschema",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 env_list =
+    py{310,311}-take2,
+    py{310,311}-take2coords,
     py{310,311}-main,
     py{310,311}-coords,
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 env_list =
-    py{310,311}-take2,
-    py{310,311}-take2coords,
     py{310,311}-main,
     py{310,311}-coords,
+    py{310,311}-take2,
+    py{310,311}-take2coords
 
 minversion = 4.23.0
 
@@ -29,7 +29,8 @@ commands =
 setenv =
     XFAILS=1
     ; We expect correctness checks to fail here because coordinate discovery isn't 
-    ; enabled in the main branch of intake-esm. This enables xfail marks in conftest.py.
+    ; enabled in the main branch of intake-esm. This toggles on xfail marks in
+    ; conftest.py.  
 
 [testenv:coordsenabled]
 setenv =
@@ -52,6 +53,22 @@ deps =
     git+https://github.com/ACCESS-NRI/intake-esm.git@issue_660-coords#egg=intake-esm
     git+https://github.com/ACCESS-NRI/intake-dataframe-catalog.git@main#egg=intake_dataframe_catalog
     intake==0.7.0
+
+[testenv:base-take2]
+description = Pin the intake version to 0.7.0, run pytest
+deps =
+    {[testenv]deps}
+    git+https://github.com/ACCESS-NRI/intake-dataframe-catalog.git@take2#egg=intake_dataframe_catalog
+    intake>=2.0.0
+
+
+[testenv:base-take2coords]
+description = Use the ACCESS-NRI fork of intake-esm, branch issue_660-coords
+deps = 
+    {[testenv]deps}
+    git+https://github.com/ACCESS-NRI/intake-esm.git@take2-coords#egg=intake-esm
+    git+https://github.com/ACCESS-NRI/intake-dataframe-catalog.git@take2#egg=intake_dataframe_catalog
+    intake>=2.0.0
 
 [testenv:py39-main]
 basepython = python3.9
@@ -89,4 +106,38 @@ deps = {[testenv:base-coords]deps}
 setenv = {[testenv:coordsenabled]setenv}
 commands = {[testenv]commands}   
 
+[testenv:py39-take2]
+basepython = python3.9
+deps = {[testenv:base-take2]deps}
+setenv = {[testenv:coordsdisabled]setenv}
+commands = {[testenv]commands}   
 
+[testenv:py310-take2]
+basepython = python3.10
+deps = {[testenv:base-take2]deps}
+setenv = {[testenv:coordsdisabled]setenv}
+commands = {[testenv]commands}   
+
+[testenv:py311-take2]
+basepython = python3.11
+deps = {[testenv:base-take2]deps}
+setenv = {[testenv:coordsdisabled]setenv}
+commands = {[testenv]commands}   
+
+[testenv:py39-take2coords]
+basepython = python3.9
+deps = {[testenv:base-take2coords]deps}
+setenv = {[testenv:coordsenabled]setenv}
+commands = {[testenv]commands}   
+
+[testenv:py310-take2coords]
+basepython = python3.10
+deps = {[testenv:base-take2coords]deps}
+setenv = {[testenv:coordsenabled]setenv}
+commands = {[testenv]commands}   
+
+[testenv:py311-take2coords]
+basepython = python3.11
+deps = {[testenv:base-take2coords]deps}
+setenv = {[testenv:coordsenabled]setenv}
+commands = {[testenv]commands}   


### PR DESCRIPTION
This branch contains expanded testing to ensure a smooth update to intake take2. 

It won't exactly close #153, as it doesn't pin the intake version to >=2.0.0, but it:

- Relaxed intake version in `pyproject.toml` to allow for versions greater than 0.7.0, reverting #154.
- Adds tox environments for dependency configurations which test this package against the various configurations of intake (0.7.0, 2.0.7) & intake esm (no coordinates, coordinates).

There are no indications from any test environments/configurations that intake take2 causes any issues: all tests are passing, with:
-  xfail for `test_builders.py::test_parse_access_ncfile[AccessOm2Builder-access-om2/output000/ocean/ocean_grid.nc-expected0-True]` when coordinate variable discovery is not enabled in intake-esm
- All tests passing when coordinate variable discovery is enabled in intake-esm - see below table.

|                       | Intake-ESM No Coordinates | Intake-ESM w/ Coordinates    |
|-------------|-----------------------------|-------------------------------|
| Intake 0.7.0 | xfails   | all tests pass     |
| Intake 2.0.7 | xfails   | all tests pass        |

I haven't added any tox runs to CI, again due to expense of running it (see #232), but I'm now confident that we can reproducibly test against multiple intake versions. 

- This PR shouldn't introduce any package behaviour changes, only changes to allowed dependency versions & expansion of tox testing environments.
    - Since our core dependency `intake-esm` is currently pinned to 0.7.0, relaxing allowed versions of `intake` will lead to dependency resolver using `intake==0.7.0` anyway,
    -  TLDR;  this PR should in practice only expand tox environments until `intake-esm` is updated to allow `intake>=0.7.0`.