### PR TITLE
Handle case of creating new-style catalog when old-style catalog already exists

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -347,7 +347,9 @@ def _combine_storage_flags(a: str, b: str) -> str:
     """
     aflags = re.findall(STORAGE_FLAG_PATTERN, a)
     bflags = re.findall(STORAGE_FLAG_PATTERN, b)
-    return "+".join(set(aflags + bflags))
+    # Sorting the return aids in testing & comparison,
+    # plus makes it more human-readable/human-searchable
+    return "+".join(sorted(list(set(aflags + bflags))))
 
 
 def metadata_validate():

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -236,9 +236,10 @@ def build():
 
     if update:
         cat_loc = get_catalog_fp(basepath=catalog_base_path)
+        existing_cat = os.path.exists(cat_loc)
 
         # See if there's an existing catalog
-        if os.path.exists(cat_loc):
+        if existing_cat:
             with Path(cat_loc).open(mode="r") as fobj:
                 yaml_old = yaml.safe_load(fobj)
 
@@ -249,6 +250,11 @@ def build():
             # - driver
             # If these have changed, we need to move the old catalog aside,
             # labelled with its min and max version numbers
+            # The exception to this rule is if the old catalog doesn't have
+            # a min or max version - this makes it likely to be an old-style
+            # catalog, so we'll need to grab its storage flags, but we don't
+            # want to save it (we assume all existing catalog versions are
+            # compatible with the new one).
 
             args_new, args_old = (
                 yaml_dict["sources"]["access_nri"]["args"],
@@ -259,15 +265,19 @@ def build():
                 yaml_old["sources"]["access_nri"]["driver"],
             )
             vmin_old, vmax_old = (
-                yaml_old["sources"]["access_nri"]["parameters"]["version"]["min"],
-                yaml_old["sources"]["access_nri"]["parameters"]["version"]["max"],
+                yaml_old["sources"]["access_nri"]["parameters"]["version"].get("min"),
+                yaml_old["sources"]["access_nri"]["parameters"]["version"].get("max"),
             )
             storage_new, storage_old = (
                 yaml_dict["sources"]["access_nri"]["metadata"]["storage"],
                 yaml_old["sources"]["access_nri"]["metadata"]["storage"],
             )
 
-            if args_new != args_old or driver_new != driver_old:
+            if (
+                (args_new != args_old or driver_new != driver_old)
+                and vmin_old is not None
+                and vmax_old is not None
+            ):
                 # Move the old catalog out of the way
                 # New catalog.yaml will have restricted version bounds
                 if vmin_old == vmax_old:
@@ -294,11 +304,11 @@ def build():
             ):
                 yaml_dict = _set_catalog_yaml_version_bounds(
                     yaml_dict,
-                    min(version, vmin_old),
-                    max(version, vmax_old),
+                    min(version, vmin_old if vmin_old is not None else version),
+                    max(version, vmax_old if vmax_old is not None else version),
                 )
 
-        else:
+        if (not existing_cat) or (vmin_old is None and vmax_old is None):
             # No existing catalog, so set min = max = current version,
             # unless there are folders with the right names in the write
             # directory

--- a/tests/data/catalog/catalog-orig.yaml
+++ b/tests/data/catalog/catalog-orig.yaml
@@ -1,0 +1,22 @@
+sources:
+  access_nri:
+    args:
+      columns_with_iterables:
+      - model
+      - realm
+      - frequency
+      - variable
+      mode: r
+      name_column: name
+      path: /g/data/xp65/public/apps/access-nri-intake-catalog/{{version}}/metacatalog.csv
+      yaml_column: yaml
+    description: ACCESS-NRI intake catalog
+    driver: intake_dataframe_catalog.core.DfFileCatalog
+    metadata:
+      storage: gdata/fs38+gdata/oi10+gdata/tm70+gdata/dc19
+      version: '{{version}}'
+    parameters:
+      version:
+        default: v0.1.3
+        description: Catalog version
+        type: str

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import glob
 import os
 import shutil
 import tempfile
@@ -482,8 +483,10 @@ def test_build_existing_data_existing_old_cat(
         cat_yaml["sources"]["access_nri"]["metadata"]["storage"]
         == "gdata/al33+gdata/dc19+gdata/fs38+gdata/oi10+gdata/tm70"
     )
-
-    # import pdb; pdb.set_trace()
+    # Make sure the old catalog vanished (i.e. there's only one)
+    assert (
+        len(glob.glob(mockargs.return_value.build_base_path + "/*.yaml")) == 1
+    ), "Found more than one catalog remains!"
 
 
 @mock.patch("access_nri_intake.cli.get_catalog_fp")


### PR DESCRIPTION
Fixes #246 .

This PR handles the case where a new-style catalog (vYYYY-MM-DD) is built, but an old-style catalog (vX.X.X) is present in the catalog build directory.

The code will now treat this the same as a no-catalog-exists case (new `catalog.yaml`, set min and max version based on the catalog directories present), with the exception that the storage flags from the old-style catalog will be merged in.