### PR TITLE
223-model-required

### DIFF
--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -203,14 +203,14 @@ class CatalogManager:
                 self.dfcat.add(self.source, row.to_dict(), overwrite=overwrite)
             except DfFileCatalogError as exc:
                 # If we have 'model' in the error message, it likely relates to
-                # issues discussed at https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223
-                # , so if the error message contains 'model', we wrap the error
-                # with some additional information about model catalog issues
-                # and then raise
-                if "model" in str(exc):
+                # issues discussed at https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223,
+                # so if the error message contains 'model', we wrap the error with some
+                # additional information about model catalog issues and then raise
+                if "iterable metadata" in str(exc):
                     raise CatalogManagerError(
-                        f"Error adding source {name} to the catalog due to model field. "
-                        " See https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223 "
+                        f"Error adding source '{name}' to the catalog due to iterable metadata issues. "
+                        " See https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223: likely"
+                        " due to issues with 'model' column in the catalog"
                     ) from exc
                 raise CatalogManagerError(exc)
             overwrite = False

--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -1,13 +1,13 @@
 # Copyright 2023 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
-""" Manager for adding/updating intake sources in an intake-dataframe-catalog like the ACCESS-NRI catalog """
+"""Manager for adding/updating intake sources in an intake-dataframe-catalog like the ACCESS-NRI catalog"""
 
 import os
 from typing import Optional, Union
 
 import intake
-from intake_dataframe_catalog.core import DfFileCatalog
+from intake_dataframe_catalog.core import DfFileCatalog, DfFileCatalogError
 
 from ..utils import validate_against_schema
 from . import (
@@ -23,6 +23,7 @@ from .translators import DefaultTranslator
 
 class CatalogManagerError(Exception):
     "Generic Exception for the CatalogManager class"
+
     pass
 
 
@@ -198,7 +199,20 @@ class CatalogManager:
 
         overwrite = True
         for _, row in self.source_metadata.iterrows():
-            self.dfcat.add(self.source, row.to_dict(), overwrite=overwrite)
+            try:
+                self.dfcat.add(self.source, row.to_dict(), overwrite=overwrite)
+            except DfFileCatalogError as exc:
+                # If we have 'model' in the error message, it likely relates to
+                # issues discussed at https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223
+                # , so if the error message contains 'model', we wrap the error
+                # with some additional information about model catalog issues
+                # and then raise
+                if "model" in str(exc):
+                    raise CatalogManagerError(
+                        f"Error adding source {name} to the catalog due to model field. "
+                        " See https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223 "
+                    ) from exc
+                raise CatalogManagerError(exc)
             overwrite = False
 
     def save(self, **kwargs):

--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -202,10 +202,10 @@ class CatalogManager:
             try:
                 self.dfcat.add(self.source, row.to_dict(), overwrite=overwrite)
             except DfFileCatalogError as exc:
-                # If we have 'model' in the error message, it likely relates to
+                # If we have 'iterable metadata' in the error message, it likely relates to
                 # issues discussed at https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues/223,
-                # so if the error message contains 'model', we wrap the error with some
-                # additional information about model catalog issues and then raise
+                # so if the error message contains 'iterable metadata', we wrap the error with some
+                # additional information about catalog issues and then raise
                 if "iterable metadata" in str(exc):
                     raise CatalogManagerError(
                         f"Error adding source '{name}' to the catalog due to iterable metadata issues. "

--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -15,6 +15,7 @@ import tlz
 from intake import DataSource
 
 from . import COLUMNS_WITH_ITERABLES
+from .utils import _to_tuple, tuplify_series
 
 FREQUENCY_TRANSLATIONS = {
     "monthly-averaged-by-hour": "1hr",
@@ -33,36 +34,6 @@ FREQUENCY_TRANSLATIONS = {
     "yr": "1yr",
     "yrPt": "1yr",
 }
-
-
-def _to_tuple(series: pd.Series) -> pd.Series:
-    """
-    Make each entry in the provided series a tuple
-
-    Parameters
-    ----------
-    series: :py:class:`~pandas.Series`
-        A pandas Series or another object with an `apply` method
-    """
-    return series.apply(lambda x: (x,))
-
-
-def tuplify_series(func: Callable) -> Callable:
-    """
-    Decorator that wraps a function that returns a pandas Series and converts
-    each entry in the series to a tuple
-    """
-
-    def wrapper(*args, **kwargs):
-        # Check if the first argument is 'self'
-        if len(args) > 0 and hasattr(args[0], "__class__"):
-            self = args[0]
-            series = func(self, *args[1:], **kwargs)
-        else:
-            series = func(*args, **kwargs)
-        return _to_tuple(series)
-
-    return wrapper
 
 
 class TranslatorError(Exception):

--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -203,12 +203,7 @@ class DefaultTranslator:
         """
         Return model from dispatch_keys.model
         """
-        try:
-            return self.source.df[self._dispatch_keys.model]
-        except KeyError as exc:
-            raise TranslatorError(
-                f"Could not translate 'model' from {self.source.esmcat.catalog_file} using {self.__class__.__name__}"
-            ) from exc
+        return self.source.df[self._dispatch_keys.model]
 
     @tuplify_series
     def _frequency_translator(self) -> pd.Series:

--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -203,7 +203,12 @@ class DefaultTranslator:
         """
         Return model from dispatch_keys.model
         """
-        return self.source.df[self._dispatch_keys.model]
+        try:
+            return self.source.df[self._dispatch_keys.model]
+        except KeyError as exc:
+            raise TranslatorError(
+                f"Could not translate 'model' from {self.source.esmcat.catalog_file} using {self.__class__.__name__}"
+            ) from exc
 
     @tuplify_series
     def _frequency_translator(self) -> pd.Series:

--- a/src/access_nri_intake/catalog/utils.py
+++ b/src/access_nri_intake/catalog/utils.py
@@ -1,0 +1,28 @@
+from typing import Callable
+
+import pandas as pd
+
+
+def _to_tuple(series: pd.Series) -> pd.Series:
+    """
+    Make each entry in the provided series a tuple
+
+    Parameters
+    ----------
+    series: :py:class:`~pandas.Series`
+        A pandas Series or another object with an `apply` method
+    """
+    return series.apply(lambda x: (x,))
+
+
+def tuplify_series(func: Callable) -> Callable:
+    """
+    Decorator that wraps a function that returns a pandas Series and converts
+    each entry in the series to a tuple
+    """
+
+    def wrapper(*args, **kwargs):
+        series = func(*args, **kwargs)
+        return _to_tuple(series)
+
+    return wrapper


### PR DESCRIPTION
# Changes
- I fixed up a couple of tangentially related bits in the translators - looks like some WIP got accidentally merged in the @tuplify_series decorator & moved that to a separate file.
- Added more thorough error handling, checking for specific data issues & pointing to #223 is it appears to be related.
- Tests for error handling. 
   - The tests use mock raises - I'd really rather avoid this if possible & pass data broken in the specific expected ways, but it was sinking too much time so I'll raise it as a new issue & come back to check. 

