### PR TITLE
Add missing experiments to build script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 This CHANGELOG documents only key changes between versions. For a full description 
 of all changes see https://github.com/ACCESS-NRI/access-nri-intake-catalog/releases
 
+v1.0.0
+------
+
+02/12/2024
+
+- Switch to stable release
+- Added MOM6 data support
+- Unit test fixes & upgrades
+- Documentation upgrades, obsolete data references removed
+
 v0.1.5
 ------
 

--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -31,7 +31,7 @@ module load openmpi
 
 OUTPUT_BASE_PATH=/g/data/xp65/public/apps/access-nri-intake-catalog
 CONFIG_DIR=/g/data/xp65/admin/access-nri-intake-catalog/config
-CONFIGS=( cmip5.yaml cmip6.yaml access-om2.yaml access-cm2.yaml access-esm1-5.yaml )
+CONFIGS=( cmip5.yaml cmip6.yaml access-om2.yaml access-cm2.yaml access-esm1-5.yaml ccam.yaml barpa.yaml cordex.yaml mom6.yaml narclim2.yaml era5.yaml )
 
 config_paths=( "${CONFIGS[@]/#/${CONFIG_DIR}/}" )
 


### PR DESCRIPTION
It looks like a lot of experiments got missed in the build script when new data requests were merged in. Not sure how that happened, but this PR corrects it.