### PR TITLE
Metadata fixes for ig45 cordex

### DIFF
--- a/config/metadata_sources/cordex-ig45/metadata.yaml
+++ b/config/metadata_sources/cordex-ig45/metadata.yaml
@@ -7,8 +7,8 @@ long_description: >-
 model:
 - CMIP6
 frequency:
-- day
-- mon
+- 1day
+- 1mon
 - 1hr
 - fx
 variable:
@@ -121,6 +121,7 @@ license:
 url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f7465_8388_5100_7022
 parent_experiment:
 related_experiments:
+- 
 notes: 
 keywords:
 - cmip


### PR DESCRIPTION
Fixes #283 .

There were some (very minor) metadata fixes required for the `ig45` CORDEX experiment. @charles-turner-1 is pushing these changes to the 'live' version of the metadata on `xp65`.

Note that this PR isn't strictly necessary for v1.0.0 (#230 ), but it's good to keep the repo reference copies up-to-date with the live copies.