### PR TITLE
Fix metadata bugs in ERA5, Narclim

### DIFF
--- a/config/metadata_sources/era5-rt52/metadata.yaml
+++ b/config/metadata_sources/era5-rt52/metadata.yaml
@@ -285,19 +285,21 @@ version:
 contact: NCI
 email: help@nci.org.au
 created: 2020-08-28 
-reference: 
-- https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.3803
-- https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.4174
-- https://www.ecmwf.int/en/elibrary/81149-global-stratospheric-temperature-bias-and-other-stratospheric-aspects-era5-and
-- https://www.ecmwf.int/en/elibrary/19911-low-frequency-variability-and-trends-surface-air-temperature-and-humidity-era5-and
-- https://www.ecmwf.int/en/publications/search?searc_all_field=era5
+reference: >-
+  https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.3803
+  https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.4174
+  https://www.ecmwf.int/en/elibrary/81149-global-stratospheric-temperature-bias-and-other-stratospheric-aspects-era5-and
+  https://www.ecmwf.int/en/elibrary/19911-low-frequency-variability-and-trends-surface-air-temperature-and-humidity-era5-and
+  https://www.ecmwf.int/en/publications/search?searc_all_field=era5
 license: https://apps.ecmwf.int/datasets/licences/copernicus/
 url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f2836_1346_3774_9763
 parent_experiment: 
 related_experiments:
+- 
 notes: >-
  This dataset contains hourly and monthly averaged data, as well as monthly 
  data averaged by hour (eg January Mean, 00:00-01:00) and monthly data averaged by day
  (same format, different name convention, eg. January Mean, 00:00-01:00). era5-derived
  contains daily data.
 keywords:
+- 

--- a/config/metadata_sources/narclim2-zz63/metadata.yaml
+++ b/config/metadata_sources/narclim2-zz63/metadata.yaml
@@ -2,14 +2,14 @@ name: narclim2_zz63
 experiment_uuid: e238a14d-d3df-43f3-b7ff-fd247b03816e
 description: <REQUIRED Short description of the experiment (string, < 150 char)>
 long_description: >-
-  NARCliM2.0 climate projections dynamically downscaled from ACCESS-ESM1-5 r6i1p1f1 
-  historical model using the WRF regional model version NARClIM2-0-WRF412R3. Domain 
-  covers a region encompassing CORDEX Australasia (AUS-18) at approximately 18km 
-  resolution in rotated grid format. The dataset includes 1-hour, 3-hour, daily 
-  and monthly data for variables such as temperature, humidity, wind, radiation 
-  and precipitation parameters. Data are provided at 1-hour steps for surface-level 
-  variables, other data at atmospheric pressure levels or subsurface processes is 
-  provided as 3-hour, daily and monthly data. Dataset includes all of CORDEX Core 
+  NARCliM2.0 climate projections dynamically downscaled from ACCESS-ESM1-5 r6i1p1f1
+  historical model using the WRF regional model version NARClIM2-0-WRF412R3. Domain
+  covers a region encompassing CORDEX Australasia (AUS-18) at approximately 18km
+  resolution in rotated grid format. The dataset includes 1-hour, 3-hour, daily
+  and monthly data for variables such as temperature, humidity, wind, radiation
+  and precipitation parameters. Data are provided at 1-hour steps for surface-level
+  variables, other data at atmospheric pressure levels or subsurface processes is
+  provided as 3-hour, daily and monthly data. Dataset includes all of CORDEX Core
   variables, most of the CORDEX Tier 1 and just over half of CORDEX Tier 2 variables.
 model:
 - MPI-ESM1-2-HR
@@ -21,8 +21,8 @@ realm:
 - atmos
 frequency:
 - 1hr
-- mon
-- day
+- 1mon
+- 1day
 - 3hr
 - fx
 variable:
@@ -194,17 +194,18 @@ contact: NCI
 email: help@nci.org.au
 created: 2024-07-09
 reference: >-
-- https://doi.org/10.1029/2021EF002625
-- https://doi.org/10.5194/gmd-2024-41
-- https://doi.org/10.5194/gmd-2024-87
+  https://doi.org/10.1029/2021EF002625
+  https://doi.org/10.5194/gmd-2024-41
+  https://doi.org/10.5194/gmd-2024-87
 license: Creative Commons Attribution 4.0 International
 url: https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f7334_2646_2487_9846
 parent_experiment: CMIP6
 related_experiments:
-notes: 
+-
+notes:
 keywords:
 - CMIP6
 - CORDEX
-- NARCliM, 
-- GCM 
+- NARCliM
+- GCM
 - RCM

--- a/config/metadata_sources/narclim2-zz63/metadata.yaml
+++ b/config/metadata_sources/narclim2-zz63/metadata.yaml
@@ -1,6 +1,6 @@
 name: narclim2_zz63
 experiment_uuid: e238a14d-d3df-43f3-b7ff-fd247b03816e
-description: <REQUIRED Short description of the experiment (string, < 150 char)>
+description:  NARCliM2.0 climate pojections, downscaled from ACCESS-ESM1-5 over Australasia at ~18km resolution.
 long_description: >-
   NARCliM2.0 climate projections dynamically downscaled from ACCESS-ESM1-5 r6i1p1f1
   historical model using the WRF regional model version NARClIM2-0-WRF412R3. Domain


### PR DESCRIPTION
Fixes #286.

This PR contains metadata format fixes for the experiments `era5-rt52` and `narclim2-zz63`.

@charles-turner-1 before approving the PR and merging, you'll need to copy both of the new files over to the live location on `xp65` (I found a stray comma in the narclim keywords list that I dealt with).