### PR TITLE
328 datastore names

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -632,11 +632,33 @@ def use_esm_datastore(argv: Sequence[str] | None = None) -> int:
         ),
     )
 
+    parser.add_argument(
+        "--datastore-name",
+        type=str,
+        help=(
+            "Name of the datastore to use. If not provided, this will default to"
+            " 'experiment_datastore'."
+        ),
+        default="experiment_datastore",
+    )
+
+    parser.add_argument(
+        "--description",
+        type=str,
+        help=(
+            "Description of the datastore. If not provided, a default description will be used:"
+            " 'esm_datastore for the model output in {--expt-dir}'"
+        ),
+        default=None,
+    )
+
     args = parser.parse_args(argv)
     builder = args.builder
     experiment_dir = Path(args.expt_dir)
     catalog_dir = Path(args.cat_dir) if args.cat_dir else experiment_dir
     builder_kwargs = args.builder_kwargs or {}
+    datastore_name = args.datastore_name
+    description = args.description
 
     try:
         builder = getattr(builders, builder)
@@ -664,6 +686,8 @@ def use_esm_datastore(argv: Sequence[str] | None = None) -> int:
         builder,
         catalog_dir,
         builder_kwargs=builder_kwargs,
+        datastore_name=datastore_name,
+        description=description,
         open_ds=False,
     )
 

--- a/src/access_nri_intake/experiment/utils.py
+++ b/src/access_nri_intake/experiment/utils.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import re
 import warnings
@@ -305,10 +306,12 @@ def parse_kwargs(kwargs: str) -> dict:
     for item in kwargs.split():
         kw, arg = item.split("=")
         if kw == "ensemble":
-            if arg.lower() not in ["true", "false"]:
+            try:
+                ret[kw] = ast.literal_eval(arg.capitalize())
+                if not isinstance(ret[kw], bool):
+                    raise ValueError
+            except (ValueError, SyntaxError):
                 raise TypeError(f"Ensemble kwarg must be a boolean, not {arg}.")
-            else:
-                ret[kw] = True if arg.lower() == "true" else False
 
     return ret
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -456,6 +456,11 @@ def test_validate_args(builder: str, kwargs, fails, err_msg):
             None,
         ),
         (
+            "ensemble=1",
+            True,
+            None,
+        ),
+        (
             "esnmebel=True",
             False,
             {},


### PR DESCRIPTION
Closes #328 .

- I also rewrote the parse_kwargs functionality to use ast.literal_eval instead of some very custom logic. Potentially this could be cleaned up further - I suspect argparse might have something in it that negates the need for it.
- [x] tweak the docs in #327 to reflect this change.