### PR TITLE
Make catalog build robust against bad experiment metadata

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -78,7 +78,7 @@ def _parse_build_inputs(
                 )
             except jsonschema.exceptions.ValidationError:
                 warnings.warn(
-                    f"Failed to validate metadata.yaml @ {Path(metadata_yaml).parent}. See traceback for details."
+                    rf"Failed to validate metadata.yaml @ {Path(metadata_yaml).parent}. See traceback for details:n\{traceback.format_exc()}"
                 )
                 warnings.warn(traceback.format_exc())
                 continue  # Skip the experiment w/ bad metadata

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -80,7 +80,6 @@ def _parse_build_inputs(
                 warnings.warn(
                     rf"Failed to validate metadata.yaml @ {Path(metadata_yaml).parent}. See traceback for details:n\{traceback.format_exc()}"
                 )
-                warnings.warn(traceback.format_exc())
                 continue  # Skip the experiment w/ bad metadata
 
             source_args["name"] = metadata["name"]

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -69,7 +69,7 @@ def _parse_build_inputs(
                 metadata_yaml = kwargs.pop("metadata_yaml")
             except KeyError:
                 raise KeyError(
-                    f"Could not find metadata_yaml kawrg for {config_yaml} - keys are {kwargs}"
+                    f"Could not find metadata_yaml kwarg for {config_yaml} - keys are {kwargs}"
                 )
 
             try:

--- a/tests/data/config/access-om2-bad-labels.yaml
+++ b/tests/data/config/access-om2-bad-labels.yaml
@@ -1,0 +1,9 @@
+builder: AccessOm2Builder
+
+translator: DefaultTranslator
+
+sources:
+
+  - path:
+      - access-om2
+    metadata: access-om2/metadata-bad.yaml

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,7 +224,7 @@ def test_build_bad_metadata(test_data, tmp_path):
     data_base_path = str(test_data)
     build_base_path = str(tmp_path)
 
-    with pytest.raises(MetadataCheckError):
+    with pytest.warns(UserWarning):
         build(
             [
                 *configs,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,36 @@ def test_build_bad_metadata(test_data, tmp_path):
         )
 
 
+def test_build_bad_metadata_no_metadata_yaml_value(test_data, tmp_path):
+    """
+    Test if bad metadata is detected
+    """
+
+    configs = [
+        str(test_data / "config/access-om2-bad-labels.yaml"),
+    ]
+    data_base_path = str(test_data)
+    build_base_path = str(tmp_path)
+
+    with pytest.raises(KeyError, match="Could not find metadata_yaml kwarg"):
+        build(
+            [
+                *configs,
+                "--catalog_file",
+                "cat.csv",
+                "--data_base_path",
+                data_base_path,
+                "--build_base_path",
+                build_base_path,
+                "--catalog_base_path",
+                build_base_path,
+                "--version",
+                "v2024-01-01",
+                "--no_update",
+            ]
+        )
+
+
 def test_build_repeat_nochange(test_data, tmp_path):
     """
     Test if the intelligent versioning works correctly when there is


### PR DESCRIPTION
(Re) closes #307 .

This PR makes a minor change - if bad experiment metadata is encountered, rather than raising an Exception, a warning is produced instead, and the experiment is not included in the resulting catalog.