### PR TITLE
Bump intake-dataframe-catalog requirement

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - cftime
     - ecgtools>=2023.7.13
     - intake>=0.7.0
-    - intake-dataframe-catalog>=0.2.4
+    - intake-dataframe-catalog>=0.3.1
     - intake-esm>=2023.11.10
     - jsonschema
     - pooch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "cftime",
     "ecgtools>=2023.7.13",
     "intake>=0.7.0",
-    "intake-dataframe-catalog>=0.2.4",
+    "intake-dataframe-catalog>=0.3.1",
     "intake-esm>=2023.11.10",
     "jsonschema",
     "pooch",


### PR DESCRIPTION
Related to issue in #335.

Should really have included this in v1.1.0 really - maybe v1.1.1 is coming sooner than expected.  