### PR TITLE
Set include_patterns/exclude_patterns from configuration YAMLs

### DIFF
--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -117,7 +117,7 @@ class CatalogManager:
         builder.save(name=name, description=description, directory=directory)
 
         self.source, self.source_metadata = _open_and_translate(
-            json_file,
+            str(json_file),
             "esm_datastore",
             name,
             description,

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -366,7 +366,7 @@ class AccessOm2Builder(BaseBuilder):
         r"^ocean.*[^\d]_(\d{2})$",  # A few wierd files in ACCESS-OM2 01deg_jra55v13_ryf9091
     ]
 
-    def __init__(self, path):
+    def __init__(self, path, **kwargs):
         """
         Initialise a AccessOm2Builder
 
@@ -379,8 +379,8 @@ class AccessOm2Builder(BaseBuilder):
         kwargs = dict(
             path=path,
             depth=3,
-            exclude_patterns=["*restart*", "*o2i.nc"],
-            include_patterns=["*.nc"],
+            exclude_patterns=kwargs.get("exclude_patterns") or ["*restart*", "*o2i.nc"],
+            include_patterns=kwargs.get("include_patterns") or ["*.nc"],
             data_format="netcdf",
             groupby_attrs=["file_id", "frequency"],
             aggregations=[
@@ -425,7 +425,7 @@ class AccessOm3Builder(BaseBuilder):
         rf"[^\.]*\.{PATTERNS_HELPERS['om3_components']}\..*?({PATTERNS_HELPERS['ymds']}|{PATTERNS_HELPERS['ymd']}|{PATTERNS_HELPERS['ym']}|{PATTERNS_HELPERS['y']})(?:$|{PATTERNS_HELPERS['not_multi_digit']})",  # ACCESS-OM3
     ]
 
-    def __init__(self, path):
+    def __init__(self, path, **kwargs):
         """
         Initialise a AccessOm3Builder
 
@@ -438,14 +438,15 @@ class AccessOm3Builder(BaseBuilder):
         kwargs = dict(
             path=path,
             depth=2,
-            exclude_patterns=[
+            exclude_patterns=kwargs.get("exclude_patterns")
+            or [
                 "*restart*",
                 "*MOM_IC.nc",
                 "*ocean_geometry.nc",
                 "*ocean.stats.nc",
                 "*Vertical_coordinate.nc",
             ],
-            include_patterns=["*.nc"],
+            include_patterns=kwargs.get("include_patterns") or ["*.nc"],
             data_format="netcdf",
             groupby_attrs=["file_id", "frequency"],
             aggregations=[
@@ -497,7 +498,7 @@ class Mom6Builder(BaseBuilder):
     ]
     TIME_PARSER = GfdlTimeParser
 
-    def __init__(self, path):
+    def __init__(self, path, **kwargs):
         """
         Initialise a Mom6Builder
 
@@ -510,7 +511,8 @@ class Mom6Builder(BaseBuilder):
         kwargs = dict(
             path=path,
             depth=1,
-            exclude_patterns=[
+            exclude_patterns=kwargs.get("exclude_patterns")
+            or [
                 "*restart*",
                 "*MOM_IC.nc",
                 "*sea_ice_geometry.nc",
@@ -518,7 +520,7 @@ class Mom6Builder(BaseBuilder):
                 "*ocean.stats.nc",
                 "*Vertical_coordinate.nc",
             ],
-            include_patterns=["*.nc"],
+            include_patterns=kwargs.get("include_patterns") or ["*.nc"],
             data_format="netcdf",
             groupby_attrs=["file_id", "frequency"],
             aggregations=[
@@ -563,7 +565,7 @@ class AccessEsm15Builder(BaseBuilder):
         r"^.*\.p.-(\d{6})_.*",  # ACCESS-ESM1.5 atmosphere
     ]
 
-    def __init__(self, path, ensemble: bool):
+    def __init__(self, path, ensemble: bool, **kwargs):
         """
         Initialise a AccessEsm15Builder
 
@@ -579,8 +581,8 @@ class AccessEsm15Builder(BaseBuilder):
         kwargs = dict(
             path=path,
             depth=3,
-            exclude_patterns=["*restart*"],
-            include_patterns=["*.nc*"],
+            exclude_patterns=kwargs.get("exclude_patterns") or ["*restart*"],
+            include_patterns=kwargs.get("include_patterns") or ["*.nc*"],
             data_format="netcdf",
             groupby_attrs=["file_id", "frequency"],
             aggregations=[

--- a/tests/data/config/access-om2-patterns.yaml
+++ b/tests/data/config/access-om2-patterns.yaml
@@ -8,6 +8,7 @@ sources:
       - access-om2
     metadata_yaml: access-om2/metadata.yaml
     include_patterns:
-      - "*.nc"
-    exclude-patterns:
-      - "restart*"
+      - "*ocean*"
+    exclude_patterns:
+      - "*scalar*"
+      - "*grid*"

--- a/tests/data/config/access-om2-patterns.yaml
+++ b/tests/data/config/access-om2-patterns.yaml
@@ -1,0 +1,13 @@
+builder: AccessOm2Builder
+
+translator: DefaultTranslator
+
+sources:
+
+  - path:
+      - access-om2
+    metadata_yaml: access-om2/metadata.yaml
+    include_patterns:
+      - "*.nc"
+    exclude-patterns:
+      - "restart*"

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -2486,3 +2486,60 @@ def test_parse_access_ncfile(test_data, builder, filename, expected, compare_fil
     xr_ds = xr_ds[expected.variable]
 
     xr.testing.assert_equal(ie_ds, xr_ds)
+
+
+@pytest.mark.parametrize(
+    "builder,default_include,default_exclude",
+    [
+        (builders.BaseBuilder, [], []),
+        (builders.AccessOm2Builder, ["*.nc"], ["*restart*", "*o2i.nc"]),
+        (
+            builders.AccessOm3Builder,
+            ["*.nc"],
+            [
+                "*restart*",
+                "*MOM_IC.nc",
+                "*ocean_geometry.nc",
+                "*ocean.stats.nc",
+                "*Vertical_coordinate.nc",
+            ],
+        ),
+        (
+            builders.Mom6Builder,
+            ["*.nc"],
+            [
+                "*restart*",
+                "*MOM_IC.nc",
+                "*sea_ice_geometry.nc",
+                "*ocean_geometry.nc",
+                "*ocean.stats.nc",
+                "*Vertical_coordinate.nc",
+            ],
+        ),
+        (builders.AccessEsm15Builder, ["*.nc*"], ["*restart*"]),
+        (builders.AccessCm2Builder, ["*.nc*"], ["*restart*"]),
+    ],
+)
+@pytest.mark.parametrize("include_patts", [None, ["include", "patterns"]])
+@pytest.mark.parametrize("exclude_patts", [None, ["exclude", "patterns"]])
+def test_builder_include_exclude_patterns(
+    builder, default_include, default_exclude, include_patts, exclude_patts, tmpdir
+):
+    if builder == builders.AccessEsm15Builder or builder == builders.AccessCm2Builder:
+        additional = [
+            False,
+        ]
+    else:
+        additional = []
+    bld = builder(
+        str(tmpdir),
+        *additional,
+        include_patterns=include_patts,
+        exclude_patterns=exclude_patts,
+    )  # ensemble needed for ESM builder
+    assert bld.include_patterns == (
+        include_patts if include_patts is not None else default_include
+    )
+    assert bld.exclude_patterns == (
+        exclude_patts if exclude_patts is not None else default_exclude
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,15 +120,19 @@ def test_check_build_args(args, raises):
         "2024-01-01",
     ],
 )
-def test_build(version, test_data, tmpdir):
+@pytest.mark.parametrize(
+    "input_list",
+    [
+        ["config/access-om2.yaml", "config/cmip5.yaml"],
+        ["config/access-om2-patterns.yaml", "config/cmip5.yaml"],
+    ],
+)
+def test_build(version, input_list, test_data, tmpdir):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmpdir)
 
-    configs = [
-        str(test_data / fname)
-        for fname in ["config/access-om2.yaml", "config/cmip5.yaml"]
-    ]
+    configs = [str(test_data / fname) for fname in input_list]
 
     build(
         [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,13 +121,19 @@ def test_check_build_args(args, raises):
     ],
 )
 @pytest.mark.parametrize(
-    "input_list",
+    "input_list, expected_size",
     [
-        ["config/access-om2.yaml", "config/cmip5.yaml"],
-        ["config/access-om2-patterns.yaml", "config/cmip5.yaml"],
+        (
+            ["config/access-om2.yaml", "config/cmip5.yaml"],
+            {"1deg_jra55_ryf9091_gadi": 12, "cmip5_al33": 5},
+        ),
+        (
+            ["config/access-om2-patterns.yaml", "config/cmip5.yaml"],
+            {"1deg_jra55_ryf9091_gadi": 6, "cmip5_al33": 5},
+        ),
     ],
 )
-def test_build(version, input_list, test_data, tmpdir):
+def test_build(version, input_list, expected_size, test_data, tmpdir):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmpdir)
@@ -160,6 +166,10 @@ def test_build(version, input_list, test_data, tmpdir):
     build_path = Path(build_base_path) / version / "cat.csv"
     cat = intake.open_df_catalog(build_path)
     assert len(cat) == 2
+
+    # Check that the individual experiment sizes are as expected
+    for exp, size in expected_size.items():
+        assert len(cat[exp].df) == size, f"Catalog size mismatch for {exp}"
 
     # Check that the metacatalog is correct
     metacat = Path(build_base_path) / "catalog.yaml"


### PR DESCRIPTION
Closes #343 .

This PR updates all existing builders in `main` to allow the builder `include_patterns` and `exclude_patterns` to be specified from the configuration YAML file on a per-experiment basis. The previously-used defaults are still in place if one/both of those values are not defined in the configuration YAML.

Tests included.