### PR TITLE
Fail build if all necessary storage can't be accessed

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -487,7 +487,7 @@ def build(argv: Sequence[str] | None = None):
     storage_flags = "+".join(sorted([f"gdata/{proj}" for proj in project if proj]))
 
     # TODO add permissions check here, before any build directories are made
-    # _confirm_project_access(project)
+    _confirm_project_access(project)
 
     # Now that that's all passed, create the physical build location
     try:

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -200,9 +200,10 @@ def _confirm_project_access(projects: set[str]) -> tuple[bool, str]:
     if len(missing_projects) == 0:
         return True, ""
 
-    return False, f"Unable to access projects {', '.join(missing_projects)} - check your group memberships"
-
-
+    return (
+        False,
+        f"Unable to access projects {', '.join(missing_projects)} - check your group memberships",
+    )
 
 
 def _write_catalog_yaml(
@@ -492,9 +493,7 @@ def build(argv: Sequence[str] | None = None):
     # TODO add permissions check here, before any build directories are made
     _valid_permissions, _err_msg = _confirm_project_access(project)
     if not _valid_permissions:
-        raise RuntimeError(
-            _err_msg
-        )
+        raise RuntimeError(_err_msg)
 
     # Now that that's all passed, create the physical build location
     try:

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -490,7 +490,6 @@ def build(argv: Sequence[str] | None = None):
 
     storage_flags = "+".join(sorted([f"gdata/{proj}" for proj in project if proj]))
 
-    # TODO add permissions check here, before any build directories are made
     _valid_permissions, _err_msg = _confirm_project_access(project)
     if not _valid_permissions:
         raise RuntimeError(_err_msg)

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -183,10 +183,9 @@ def _get_project(paths: list[str], method: str | None = None):
     return project
 
 
-# Confirm access to all necessary projects
 def _confirm_project_access(projects: set[str]) -> tuple[bool, str]:
     """
-    Return False and the missing project if the user can't access all projects' /g/data spaces.
+    Return False and the missing project if the user can't access all necessary projects' /g/data spaces.
 
     Returns:
         tuple[bool, str]: Whether the user can access all projects, and a string of any missing projects

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,7 +135,9 @@ def test_check_build_args(args, raises):
     ],
 )
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build(mock_confirm_project_access,version, input_list, expected_size, test_data, tmpdir):
+def test_build(
+    mock_confirm_project_access, version, input_list, expected_size, test_data, tmpdir
+):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmpdir)
@@ -200,7 +202,7 @@ def test_build(mock_confirm_project_access,version, input_list, expected_size, t
     ],
 )
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_bad_version(mock_confirm_project_access,bad_vers, test_data, tmp_path):
+def test_build_bad_version(mock_confirm_project_access, bad_vers, test_data, tmp_path):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmp_path)
@@ -230,7 +232,7 @@ def test_build_bad_version(mock_confirm_project_access,bad_vers, test_data, tmp_
 
 
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_bad_metadata(mock_confirm_project_access,test_data, tmp_path):
+def test_build_bad_metadata(mock_confirm_project_access, test_data, tmp_path):
     """
     Test if bad metadata is detected
     """
@@ -262,7 +264,9 @@ def test_build_bad_metadata(mock_confirm_project_access,test_data, tmp_path):
 
 
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_bad_metadata_no_metadata_yaml_value(mock_confirm_project_access,test_data, tmp_path):
+def test_build_bad_metadata_no_metadata_yaml_value(
+    mock_confirm_project_access, test_data, tmp_path
+):
     """
     Test if bad metadata is detected
     """
@@ -293,7 +297,7 @@ def test_build_bad_metadata_no_metadata_yaml_value(mock_confirm_project_access,t
 
 
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_repeat_nochange(mock_confirm_project_access,test_data, tmp_path):
+def test_build_repeat_nochange(mock_confirm_project_access, test_data, tmp_path):
     """
     Test if the intelligent versioning works correctly when there is
     no significant change to the underlying catalogue
@@ -359,7 +363,7 @@ def test_build_repeat_nochange(mock_confirm_project_access,test_data, tmp_path):
 
 
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_repeat_adddata(mock_confirm_project_access,test_data, tmp_path):
+def test_build_repeat_adddata(mock_confirm_project_access, test_data, tmp_path):
     configs = [
         str(test_data / "config/access-om2.yaml"),
     ]
@@ -426,7 +430,11 @@ def test_build_repeat_adddata(mock_confirm_project_access,test_data, tmp_path):
 @mock.patch("access_nri_intake.cli._get_project_code", return_value="aa99")
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_project_base_code(
-    mock_confirm_project_access,mock_get_project, mock_get_project_code, test_data, tmp_path
+    mock_confirm_project_access,
+    mock_get_project,
+    mock_get_project_code,
+    test_data,
+    tmp_path,
 ):
     configs = [
         str(test_data / "config/access-om2.yaml"),
@@ -467,7 +475,9 @@ def test_build_project_base_code(
     ],
 )
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_existing_data(mock_confirm_project_access,test_data, min_vers, max_vers, tmp_path):
+def test_build_existing_data(
+    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
+):
     """
     Test if the build process can handle min and max catalog
     versions when an original catalog.yaml does not exist
@@ -527,7 +537,9 @@ def test_build_existing_data(mock_confirm_project_access,test_data, min_vers, ma
     ],
 )
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_existing_data_existing_old_cat(mock_confirm_project_access,test_data, min_vers, max_vers, tmp_path):
+def test_build_existing_data_existing_old_cat(
+    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
+):
     """
     Test if the build process can handle min and max catalog
     versions when a old-style catalog.yaml exists
@@ -600,7 +612,7 @@ def test_build_existing_data_existing_old_cat(mock_confirm_project_access,test_d
 )
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_separation_between_catalog_and_buildbase(
-    mock_confirm_project_access,test_data, min_vers, max_vers, tmp_path
+    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
 ):
     """
     Test if the intelligent versioning works correctly when there is
@@ -868,7 +880,7 @@ def test_build_repeat_altercatalogstruct(test_data, min_vers, max_vers, tmp_path
 )
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_repeat_altercatalogstruct_multivers(
-    mock_confirm_project_access,test_data, min_vers, max_vers, tmp_path
+    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
 ):
     configs = [
         str(test_data / "config/cmip5.yaml"),
@@ -1338,19 +1350,32 @@ def test_scaffold_catalog_entry():
     ):
         scaffold_catalog_entry(["--interactive"])
 
+
 @pytest.mark.parametrize(
     "needed_projects, valid_projects, expected",
     [
         ({"aa99"}, {"aa99"}, (True, "")),
         ({"aa99", "bb99"}, {"aa99", "bb99", "cc99"}, (True, "")),
-        ({"aa99"}, {"bb99"}, (False, "Unable to access projects aa99 - check your group memberships")),
-        ({"aa99", "bb99","cc99"}, {"aa99"}, (False, "Unable to access projects bb99, cc99 - check your group memberships")),
+        (
+            {"aa99"},
+            {"bb99"},
+            (False, "Unable to access projects aa99 - check your group memberships"),
+        ),
+        (
+            {"aa99", "bb99", "cc99"},
+            {"aa99"},
+            (
+                False,
+                "Unable to access projects bb99, cc99 - check your group memberships",
+            ),
+        ),
     ],
 )
 def test_confirm_project_access(monkeypatch, needed_projects, valid_projects, expected):
     """
     Check that _confirm_project_access returns expected values.
     """
+
     # Create a patched version of Path.exists that checks against our accessible projects
     def mock_exists(self):
         if self.parent == Path("/g/data"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,14 @@ from access_nri_intake.cli import (
 )
 
 
+@pytest.fixture
+def fake_project_access():
+    with mock.patch(
+        "access_nri_intake.cli._confirm_project_access", return_value=(True, "")
+    ):
+        yield
+
+
 def test_entrypoint():
     """
     Check that entry point works
@@ -134,9 +142,8 @@ def test_check_build_args(args, raises):
         ),
     ],
 )
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build(
-    mock_confirm_project_access, version, input_list, expected_size, test_data, tmpdir
+    version, input_list, expected_size, test_data, tmpdir, fake_project_access
 ):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
@@ -201,8 +208,7 @@ def test_build(
         "v0.1.2",  # Old-style version numbers
     ],
 )
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_bad_version(mock_confirm_project_access, bad_vers, test_data, tmp_path):
+def test_build_bad_version(bad_vers, test_data, tmp_path, fake_project_access):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmp_path)
@@ -231,8 +237,7 @@ def test_build_bad_version(mock_confirm_project_access, bad_vers, test_data, tmp
         )
 
 
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_bad_metadata(mock_confirm_project_access, test_data, tmp_path):
+def test_build_bad_metadata(test_data, tmp_path, fake_project_access):
     """
     Test if bad metadata is detected
     """
@@ -263,9 +268,8 @@ def test_build_bad_metadata(mock_confirm_project_access, test_data, tmp_path):
         )
 
 
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_bad_metadata_no_metadata_yaml_value(
-    mock_confirm_project_access, test_data, tmp_path
+    test_data, tmp_path, fake_project_access
 ):
     """
     Test if bad metadata is detected
@@ -329,8 +333,7 @@ def test_build_no_project_access(mock_confirm_project_access, test_data, tmp_pat
         )
 
 
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_repeat_nochange(mock_confirm_project_access, test_data, tmp_path):
+def test_build_repeat_nochange(test_data, tmp_path, fake_project_access):
     """
     Test if the intelligent versioning works correctly when there is
     no significant change to the underlying catalogue
@@ -395,8 +398,7 @@ def test_build_repeat_nochange(mock_confirm_project_access, test_data, tmp_path)
     ), f'Default version {cat_yaml["sources"]["access_nri"]["parameters"]["version"].get("default")} does not match expected v2024-01-02'
 
 
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
-def test_build_repeat_adddata(mock_confirm_project_access, test_data, tmp_path):
+def test_build_repeat_adddata(test_data, tmp_path, fake_project_access):
     configs = [
         str(test_data / "config/access-om2.yaml"),
     ]
@@ -461,13 +463,8 @@ def test_build_repeat_adddata(mock_confirm_project_access, test_data, tmp_path):
 
 @mock.patch("access_nri_intake.cli._get_project", return_value=set())
 @mock.patch("access_nri_intake.cli._get_project_code", return_value="aa99")
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_project_base_code(
-    mock_confirm_project_access,
-    mock_get_project,
-    mock_get_project_code,
-    test_data,
-    tmp_path,
+    mock_get_project, mock_get_project_code, test_data, tmp_path, fake_project_access
 ):
     configs = [
         str(test_data / "config/access-om2.yaml"),
@@ -507,9 +504,8 @@ def test_build_project_base_code(
         ("v2001-01-01", None),
     ],
 )
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_existing_data(
-    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
+    test_data, min_vers, max_vers, tmp_path, fake_project_access
 ):
     """
     Test if the build process can handle min and max catalog
@@ -569,9 +565,8 @@ def test_build_existing_data(
         ("v2001-01-01", None),
     ],
 )
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_existing_data_existing_old_cat(
-    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
+    test_data, min_vers, max_vers, tmp_path, fake_project_access
 ):
     """
     Test if the build process can handle min and max catalog
@@ -643,9 +638,8 @@ def test_build_existing_data_existing_old_cat(
         ("v2001-01-01", None),
     ],
 )
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_separation_between_catalog_and_buildbase(
-    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
+    test_data, min_vers, max_vers, tmp_path, fake_project_access
 ):
     """
     Test if the intelligent versioning works correctly when there is
@@ -911,9 +905,8 @@ def test_build_repeat_altercatalogstruct(test_data, min_vers, max_vers, tmp_path
         ("v2001-01-01", None),
     ],
 )
-@mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_repeat_altercatalogstruct_multivers(
-    mock_confirm_project_access, test_data, min_vers, max_vers, tmp_path
+    test_data, min_vers, max_vers, tmp_path, fake_project_access
 ):
     configs = [
         str(test_data / "config/cmip5.yaml"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,6 +296,39 @@ def test_build_bad_metadata_no_metadata_yaml_value(
         )
 
 
+@mock.patch(
+    "access_nri_intake.cli._confirm_project_access",
+    return_value=(False, "Simulated access failure"),
+)
+def test_build_no_project_access(mock_confirm_project_access, test_data, tmp_path):
+    """
+    Test if the build dies because it can't access project storage area
+    """
+    configs = [
+        str(test_data / "config/access-om2.yaml"),
+        str(test_data / "config/cmip5.yaml"),
+    ]
+    data_base_path = str(test_data)
+    build_base_path = str(tmp_path)
+
+    with pytest.raises(RuntimeError, match="Simulated access failure"):
+        build(
+            [
+                *configs,
+                "--catalog_file",
+                "cat.csv",
+                "--data_base_path",
+                data_base_path,
+                "--build_base_path",
+                build_base_path,
+                "--catalog_base_path",
+                build_base_path,
+                "--version",
+                "v2024-01-01",
+            ]
+        )
+
+
 @mock.patch("access_nri_intake.cli._confirm_project_access", return_value=(True, ""))
 def test_build_repeat_nochange(mock_confirm_project_access, test_data, tmp_path):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,13 +24,18 @@ from access_nri_intake.cli import (
     use_esm_datastore,
 )
 
-# def _mock_al33_exists(*args, **kwargs):
-#     # import pdb; pdb.set_trace()
-#     try:
-#         if args[0] == "al33":
-#             return True
-#     except IndexError: pass
-#     return mock.DEFAULT
+
+def _mock_al33_exists(*args, **kwargs):
+    # import pdb; pdb.set_trace()
+    try:
+        if "al33" in args:
+            import pdb
+
+            pdb.set_trace()
+            return True
+    except IndexError:
+        pass
+    return mock.DEFAULT
 
 
 def test_entrypoint():
@@ -141,31 +146,30 @@ def test_check_build_args(args, raises):
         ),
     ],
 )
-# @mock.patch("pathlib.Path.exists")
 def test_build(version, input_list, expected_size, test_data, tmpdir):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmpdir)
-    # mock_exists.side_effect = _mock_al33_exists
 
     configs = [str(test_data / fname) for fname in input_list]
 
-    build(
-        [
-            *configs,
-            "--catalog_file",
-            "cat.csv",
-            # "--no_update",  # commented out to test brand-new-catalog-versioning
-            "--version",
-            version,
-            "--build_base_path",
-            build_base_path,
-            "--catalog_base_path",
-            build_base_path,
-            "--data_base_path",
-            str(test_data),
-        ]
-    )
+    with mock.patch("pathlib.Path.exists", side_effect=_mock_al33_exists):
+        build(
+            [
+                *configs,
+                "--catalog_file",
+                "cat.csv",
+                # "--no_update",  # commented out to test brand-new-catalog-versioning
+                "--version",
+                version,
+                "--build_base_path",
+                build_base_path,
+                "--catalog_base_path",
+                build_base_path,
+                "--data_base_path",
+                str(test_data),
+            ]
+        )
 
     # manually fix the version so we can correctly build the test path: build
     # will do this for us so we need to replicate it here

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,14 @@ from access_nri_intake.cli import (
     use_esm_datastore,
 )
 
+# def _mock_al33_exists(*args, **kwargs):
+#     # import pdb; pdb.set_trace()
+#     try:
+#         if args[0] == "al33":
+#             return True
+#     except IndexError: pass
+#     return mock.DEFAULT
+
 
 def test_entrypoint():
     """
@@ -133,10 +141,12 @@ def test_check_build_args(args, raises):
         ),
     ],
 )
+# @mock.patch("pathlib.Path.exists")
 def test_build(version, input_list, expected_size, test_data, tmpdir):
     """Test full catalog build process from config files"""
     # Update the config_yaml paths
     build_base_path = str(tmpdir)
+    # mock_exists.side_effect = _mock_al33_exists
 
     configs = [str(test_data / fname) for fname in input_list]
 


### PR DESCRIPTION
Closes #358 .

This PR adds a new check step to the catalog build process. It will cause the build to fail (early) with a `RuntimeError` if the user running the build doesn't have access to one or more of the necessary project storage areas.