### PR TITLE
Translator metadata fixes

### DIFF
--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -7,7 +7,7 @@ like the ACCESS-NRI catalog
 """
 
 from dataclasses import dataclass
-from functools import partial, wraps
+from functools import partial
 from typing import Callable
 
 import pandas as pd
@@ -15,10 +15,7 @@ import tlz
 from intake import DataSource
 
 from . import COLUMNS_WITH_ITERABLES
-from .utils import _to_tuple, tuplify_series
-
-# Note: important that when using @tuplify_series and @trace_failure decorators,
-# trace failure is the innermost decorator
+from .utils import _to_tuple, trace_failure, tuplify_series
 
 FREQUENCY_TRANSLATIONS = {
     "monthly-averaged-by-hour": "1hr",
@@ -37,29 +34,6 @@ FREQUENCY_TRANSLATIONS = {
     "yr": "1yr",
     "yrPt": "1yr",
 }
-
-
-def trace_failure(func: Callable) -> Callable:
-    """
-    Decorator that wraps a function and prints a message if it raises an exception
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        func_name = func.__name__
-        colname = func_name[1:].split("_")[0]
-        # Ensure the first argument is an instance of the class
-        if not isinstance(args[0], DefaultTranslator):
-            raise TypeError("Decorator can only be applied to class methods")
-
-        try:
-            return func(*args, **kwargs)
-        except KeyError as exc:
-            raise KeyError(
-                f"Unable to translate '{colname}' column with translator '{args[0].__class__.__name__}'"
-            ) from exc
-
-    return wrapper
 
 
 class TranslatorError(Exception):
@@ -225,16 +199,16 @@ class DefaultTranslator:
         """
         return _cmip_realm_translator(self.source.df[self._dispatch_keys.realm])
 
-    @tuplify_series
     @trace_failure
+    @tuplify_series
     def _model_translator(self) -> pd.Series:
         """
         Return model from dispatch_keys.model
         """
         return self.source.df[self._dispatch_keys.model]
 
-    @tuplify_series
     @trace_failure
+    @tuplify_series
     def _frequency_translator(self) -> pd.Series:
         """
         Return frequency, fixing a few issues
@@ -243,8 +217,8 @@ class DefaultTranslator:
             lambda x: FREQUENCY_TRANSLATIONS.get(x, x)
         )
 
-    @tuplify_series
     @trace_failure
+    @tuplify_series
     def _variable_translator(self) -> pd.Series:
         """
         Return variable as a tuple

--- a/src/access_nri_intake/catalog/utils.py
+++ b/src/access_nri_intake/catalog/utils.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Callable
 
 import pandas as pd
@@ -21,8 +22,33 @@ def tuplify_series(func: Callable) -> Callable:
     each entry in the series to a tuple
     """
 
+    @wraps(func)
     def wrapper(*args, **kwargs):
         series = func(*args, **kwargs)
         return _to_tuple(series)
+
+    return wrapper
+
+
+def trace_failure(func: Callable) -> Callable:
+    """
+    Decorator that wraps a function and prints a message if it raises an exception
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        func_name = func.__name__
+        colname = func_name[1:].split("_")[0]
+        # Check that the first argument is a DefaultTranslator (or subclass) instance
+        # This is hacky, but I want the decorators outside the main translators module
+        if not str(type(args[0]).mro()).__contains__("DefaultTranslator"):
+            raise TypeError("Decorator can only be applied to translator class methods")
+
+        try:
+            return func(*args, **kwargs)
+        except KeyError as exc:
+            raise KeyError(
+                f"Unable to translate '{colname}' column with translator '{args[0].__class__.__name__}'"
+            ) from exc
 
     return wrapper

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -393,4 +393,6 @@ def test_translator_failure(test_data):
     with pytest.raises(TypeError) as excinfo:
         _(1)
 
-    assert "Decorator can only be applied to class methods" in str(excinfo.value)
+    assert "Decorator can only be applied to translator class methods" in str(
+        excinfo.value
+    )


### PR DESCRIPTION
Around the 1.0.0 release, I added a decorator to report failing translators, but the implementation was a bit messy - wasn't preserving metadata correctly, circular import workarounds, etc.

This PR cleans that up. Low priority.