### PR TITLE
Update metadata-template CLI

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -578,7 +578,7 @@ def metadata_validate(argv: Sequence[str] | None = None):
             raise FileNotFoundError(f"No such file(s): {f}")
 
 
-def metadata_template(loc: str | Path | None = None) -> None:
+def metadata_template(argv: Sequence[str] | None = None) -> None:
     """
     Create an empty template for a metadata.yaml file using the experiment schema.
 
@@ -594,8 +594,15 @@ def metadata_template(loc: str | Path | None = None) -> None:
         None
     """
 
-    if loc is None:
-        loc = Path.cwd()
+    parser = argparse.ArgumentParser(description="Create a template metadata.yaml file")
+    parser.add_argument(
+        "--loc",
+        help="The directory in which to save the template. Defaults to the current working directory.",
+        default=str(Path.cwd()),
+    )
+
+    args = parser.parse_args(argv)
+    loc = Path(args.loc)
 
     argparse.ArgumentParser(description="Generate a template for metadata.yaml")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,12 @@
 from datetime import datetime
 from pathlib import Path
 
-from pytest import fixture
+import pytest
 
 here = Path(__file__).parent
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def test_data():
     return Path(here / "data")
 
@@ -18,24 +18,35 @@ def metadata_sources():
     return Path(here.parent / "config" / "metadata_sources")
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def config_dir():
     return Path(here / "e2e/configs")
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def live_config_dir():
     return Path(here).parent / "config"
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def BASE_DIR(tmp_path_factory):
     yield tmp_path_factory.mktemp("catalog-dir")
 
 
-@fixture(scope="session")
+@pytest.fixture(scope="session")
 def v_num():
     return datetime.now().strftime("v%Y-%m-%d")
+
+
+@pytest.fixture(autouse=True, scope="function")
+def check_metadata_cwd():
+
+    # Run test
+    yield
+
+    # Look for metadata.yaml in CWD
+    if (Path.cwd() / "metadata.yaml").is_file():
+        raise UserWarning("Stray metadata.yaml left in CWD!")
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def v_num():
     return datetime.now().strftime("v%Y-%m-%d")
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(scope="function")
 def check_metadata_cwd():
 
     # Run test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1200,6 +1200,11 @@ def test_metadata_template_default_loc():
         raise RuntimeError("Didn't write template into PWD")
 
 
+def test_metadata_template_bad_loc():
+    with pytest.raises(FileNotFoundError):
+        metadata_template(["--loc", "/path/does/not/exist"])
+
+
 @pytest.mark.parametrize(
     "builder",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1192,6 +1192,7 @@ def test_metadata_template(tmp_path):
         raise RuntimeError("Didn't write template into temp dir")
 
 
+@pytest.mark.skip
 def test_metadata_template_default_loc():
     metadata_template()
     if (Path.cwd() / "metadata.yaml").is_file():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1179,20 +1179,20 @@ def test_metadata_validate_multi(test_data):
     metadata_validate(files)
 
 
-def test_metadata_validate_no_file():
+def test_metadata_validate_no_file(check_metadata_cwd):
     """Test metadata_validate"""
     with pytest.raises(FileNotFoundError) as excinfo:
         metadata_validate(["./does/not/exist.yaml"])
     assert "No such file(s)" in str(excinfo.value)
 
 
-def test_metadata_template(tmp_path):
+def test_metadata_template(check_metadata_cwd, tmp_path):
     metadata_template(["--loc", str(tmp_path)])
     if not (tmp_path / "metadata.yaml").is_file():
         raise RuntimeError("Didn't write template into temp dir")
 
 
-def test_metadata_template_default_loc():
+def test_metadata_template_default_loc(check_metadata_cwd):
     metadata_template([])
     if (Path.cwd() / "metadata.yaml").is_file():
         (Path.cwd() / "metadata.yaml").unlink()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1187,14 +1187,13 @@ def test_metadata_validate_no_file():
 
 
 def test_metadata_template(tmp_path):
-    metadata_template(loc=tmp_path)
+    metadata_template(["--loc", str(tmp_path)])
     if not (tmp_path / "metadata.yaml").is_file():
         raise RuntimeError("Didn't write template into temp dir")
 
 
-@pytest.mark.skip
 def test_metadata_template_default_loc():
-    metadata_template()
+    metadata_template([])
     if (Path.cwd() / "metadata.yaml").is_file():
         (Path.cwd() / "metadata.yaml").unlink()
     else:


### PR DESCRIPTION
Closes #372 .

It turns out the stray `metadata.yaml` came from the `test_entrypoint` test. Because `metadata-template` did not originally use the `argparse` structure, calling `metadata-template --help` did nothing special - it just executed the command with no arguments, and hence wrote a `metadata.yaml` in the CWD with no teardown to remove it. (We didn't notice earlier because the later test that intentionally tested the CWD template write *does* have teardown, so was covering up the issue.)

This PR:
- Adds correct `argparse` usage to `metadata-template`, so `test_entrypoint` now works as expected;
- Updates the `metadata-template` tests to use correct `argparse` formatting;
- Added a per-function pytest fixture to raise a `UserWarning` if a `metadata.yaml` is left hanging in the CWD after each test.