### PR TITLE
Fix conda deps

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - versioneer
   run:
     - python >=3.10
+    - access-py-telemetry>=0.1.6
     - cftime
     - ecgtools>=2023.7.13
     - intake>=0.7.0

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python >=3.10
     - access-py-telemetry>=0.1.6
     - cftime
+    - colorama
     - ecgtools>=2023.7.13
     - intake>=0.7.0
     - intake-dataframe-catalog>=0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "xarray",
     "colorama",
     "yamanifest",
-    "access-py-telemetry>=0.1.2",
+    "access-py-telemetry>=0.1.6",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Sorry - screwed up & forgot to add the deps in `.conda/meta.yaml` too. This will have broken the catalog in 25.04 & will need a new release.

Dougie sent me something that could be used to automate syncing these dependencies up, so I'll integrate that before I make the same cockup again.