### PR TITLE
Loosen exception catch when importing catalog - errors change when a build is ongoing

### DIFF
--- a/src/access_nri_intake/data/__init__.py
+++ b/src/access_nri_intake/data/__init__.py
@@ -35,7 +35,7 @@ try:
     cat_version = data._captured_init_kwargs.get("metadata", {}).get(
         "version", "latest"
     )  # Get the catalog version number and set it to "latest" if it can't be found
-except FileNotFoundError:
+except Exception:
     warnings.warn(
         "Unable to access a default catalog location. Calling intake.cat.access_nri will not work.",
         RuntimeWarning,

--- a/src/access_nri_intake/data/__init__.py
+++ b/src/access_nri_intake/data/__init__.py
@@ -8,6 +8,7 @@ import intake
 import intake.catalog
 from access_py_telemetry.api import ApiHandler, ProductionToggle
 from access_py_telemetry.cli import configure_telemetry
+from pandas.errors import EmptyDataError
 
 from access_nri_intake.utils import get_catalog_fp
 
@@ -35,7 +36,7 @@ try:
     cat_version = data._captured_init_kwargs.get("metadata", {}).get(
         "version", "latest"
     )  # Get the catalog version number and set it to "latest" if it can't be found
-except Exception:
+except FileNotFoundError:
     warnings.warn(
         "Unable to access a default catalog location. Calling intake.cat.access_nri will not work.",
         RuntimeWarning,
@@ -43,6 +44,28 @@ except Exception:
     )
     data = intake.catalog.Catalog()
     cat_version = -999  # Failed to load a catalog - bad result flag
+except EmptyDataError:
+    warnings.warn(
+        (
+            "Catalog is empty, likely due to ongoing catalog rebuild. Please try again later."
+            " If the issue persists, please contact the ACCESS-NRI team."
+        ),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    data = intake.catalog.Catalog()
+    cat_version = -999
+except Exception as e:
+    warnings.warn(
+        (
+            f"An unexpected error occurred while loading the catalog: {e}"
+            " Please raise an issue at https://github.com/ACCESS-NRI/access-nri-intake-catalog/issues"
+        ),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    data = intake.catalog.Catalog()
+    cat_version = -999
 finally:
     configure_telemetry(["--enable", "--silent"])
     api_handler.add_extra_fields("intake_catalog", {"catalog_version": cat_version})


### PR DESCRIPTION

<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

- Change `Except FileNotFoundError` => `Except Exception`

## Related issue number 

None - this is a hotfix.

I'm pretty sure that at some points during a catalog build, we expect to see potential `EmptyDataErrors` as our default (ie. most recent build) file exists but contains no meaningful data.

I think we'll want to break this up into more meaningful exceptions, I'll raise an issue re. that.

This further triggers a telemetry error as our error handling isn't triggered as we only account for FileNotFoundError in our ecxeption handling. 

See traceback: 
```python
---------------------------------------------------------------------------
EmptyDataError                            Traceback (most recent call last)
File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/access_nri_intake/data/__init__.py:34](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/access_nri_intake/data/__init__.py#line=33)
     33 try:
---> 34     data = intake.open_catalog(get_catalog_fp()).access_nri
     35     cat_version = data._captured_init_kwargs.get("metadata", {}).get(
     36         "version", "latest"
     37     )  # Get the catalog version number and set it to "latest" if it can't be found

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:427](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=426), in Catalog.__getattr__(self, item)
    426 try:
--> 427     return self[item]  # triggers reload_on_change
    428 except KeyError as e:

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:472](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=471), in Catalog.__getitem__(self, key)
    470 if not isinstance(key, list) and key in self:
    471     # triggers reload_on_change
--> 472     s = self._get_entry(key)
    473     if s.container == "catalog":

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/utils.py:43](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/utils.py#line=42), in reload_on_change.<locals>.wrapper(self, *args, **kwargs)
     42 self.reload()
---> 43 return f(self, *args, **kwargs)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:355](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=354), in Catalog._get_entry(self, name)
    354 entry._user_parameters = ups + (entry._user_parameters or [])
--> 355 return entry()

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/entry.py:60](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/entry.py#line=59), in CatalogEntry.__call__(self, persist, **kwargs)
     59 """Instantiate DataSource with given user arguments"""
---> 60 s = self.get(**kwargs)
     61 s._entry = self

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/local.py:313](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/local.py#line=312), in LocalCatalogEntry.get(self, **user_parameters)
    312 plugin, open_args = self._create_open_args(user_parameters)
--> 313 data_source = plugin(**open_args)
    314 data_source.catalog_object = self._catalog

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake_dataframe_catalog/core.py:128](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake_dataframe_catalog/core.py#line=127), in DfFileCatalog.__init__(self, path, yaml_column, name_column, mode, columns_with_iterables, storage_options, read_kwargs, **intake_kwargs)
    126     self._allow_write = True
--> 128 super().__init__(storage_options=self.storage_options, **self._intake_kwargs)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:128](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=127), in Catalog.__init__(self, entries, name, description, metadata, ttl, getenv, getshell, persist_mode, storage_options, user_parameters)
    127 self._entries = entries if entries is not None else self._make_entries_container()
--> 128 self.force_reload()

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:186](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=185), in Catalog.force_reload(self)
    185 self.updated = time.time()
--> 186 self._load()

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake_dataframe_catalog/core.py:143](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake_dataframe_catalog/core.py#line=142), in DfFileCatalog._load(self)
    142 with fsspec.open(self.path, **self.storage_options) as fobj:
--> 143     self._df = pd.read_csv(fobj, **self._read_kwargs)
    144 if self.yaml_column not in self.df.columns:

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py:1026](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py#line=1025), in read_csv(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, date_format, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, encoding_errors, dialect, on_bad_lines, delim_whitespace, low_memory, memory_map, float_precision, storage_options, dtype_backend)
   1024 kwds.update(kwds_defaults)
-> 1026 return _read(filepath_or_buffer, kwds)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py:620](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py#line=619), in _read(filepath_or_buffer, kwds)
    619 # Create the parser.
--> 620 parser = TextFileReader(filepath_or_buffer, **kwds)
    622 if chunksize or iterator:

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py:1620](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py#line=1619), in TextFileReader.__init__(self, f, engine, **kwds)
   1619 self.handles: IOHandles | None = None
-> 1620 self._engine = self._make_engine(f, self.engine)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py:1898](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/readers.py#line=1897), in TextFileReader._make_engine(self, f, engine)
   1897 try:
-> 1898     return mapping[engine](f, **self.options)
   1899 except Exception:

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/c_parser_wrapper.py:93](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/pandas/io/parsers/c_parser_wrapper.py#line=92), in CParserWrapper.__init__(self, src, **kwds)
     92     import_optional_dependency("pyarrow")
---> 93 self._reader = parsers.TextReader(src, **kwds)
     95 self.unnamed_cols = self._reader.unnamed_cols

File parsers.pyx:581, in pandas._libs.parsers.TextReader.__cinit__()

EmptyDataError: No columns to parse from file

During handling of the above exception, another exception occurred:

NameError                                 Traceback (most recent call last)
Cell In[4], line 4
      1 import intake
----> 4 catalog = intake.cat.access_nri(version="v2025-03-04")

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:427](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=426), in Catalog.__getattr__(self, item)
    424 if not item.startswith("_"):
    425     # Fall back to __getitem__.
    426     try:
--> 427         return self[item]  # triggers reload_on_change
    428     except KeyError as e:
    429         raise AttributeError(item) from e

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:472](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=471), in Catalog.__getitem__(self, key)
    463 """Return a catalog entry by name.
    464 
    465 Can also use attribute syntax, like ``cat.entry_name``, or
   (...)
    468 cat['name1', 'name2']
    469 """
    470 if not isinstance(key, list) and key in self:
    471     # triggers reload_on_change
--> 472     s = self._get_entry(key)
    473     if s.container == "catalog":
    474         s.name = key

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/utils.py:43](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/utils.py#line=42), in reload_on_change.<locals>.wrapper(self, *args, **kwargs)
     40 @functools.wraps(f)
     41 def wrapper(self, *args, **kwargs):
     42     self.reload()
---> 43     return f(self, *args, **kwargs)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py:355](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/base.py#line=354), in Catalog._get_entry(self, name)
    353 ups = [up for name, up in self.user_parameters.items() if name not in up_names]
    354 entry._user_parameters = ups + (entry._user_parameters or [])
--> 355 return entry()

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/local.py:917](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/intake/catalog/local.py#line=916), in EntrypointEntry.__call__(self, **kwargs)
    915 def __call__(self, **kwargs):
    916     """Instantiate the DataSource for the given parameters"""
--> 917     source = self._entrypoint.load()
    918     if kwargs:
    919         source = source.configure_new(**kwargs)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/importlib_metadata/__init__.py:184](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/importlib_metadata/__init__.py#line=183), in EntryPoint.load(self)
    179 """Load the entry point from its definition. If only a module
    180 is indicated by the value, return that module. Otherwise,
    181 return the named object.
    182 """
    183 match = cast(Match, self.pattern.match(self.value))
--> 184 module = import_module(match.group('module'))
    185 attrs = filter(None, (match.group('attr') or '').split('.'))
    186 return functools.reduce(getattr, attrs, module)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/importlib/__init__.py:126](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/importlib/__init__.py#line=125), in import_module(name, package)
    124             break
    125         level += 1
--> 126 return _bootstrap._gcd_import(name[level:], package, level)

File <frozen importlib._bootstrap>:1204, in _gcd_import(name, package, level)

File <frozen importlib._bootstrap>:1176, in _find_and_load(name, import_)

File <frozen importlib._bootstrap>:1147, in _find_and_load_unlocked(name, import_)

File <frozen importlib._bootstrap>:690, in _load_unlocked(spec)

File <frozen importlib._bootstrap_external>:940, in exec_module(self, module)

File <frozen importlib._bootstrap>:241, in _call_with_frames_removed(f, *args, **kwds)

File [/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/access_nri_intake/data/__init__.py:48](https://are.nci.org.au/g/data/xp65/public/apps/med_conda/envs/analysis3-25.05/lib/python3.11/site-packages/access_nri_intake/data/__init__.py#line=47)
     46 finally:
     47     configure_telemetry(["--enable", "--silent"])
---> 48     api_handler.add_extra_fields("intake_catalog", {"catalog_version": cat_version})
     50     api_handler.send_api_request(
     51         service_name="intake_catalog",
     52         function_name="intake.cat.access_nri",
     53         args=[],
     54         kwargs={"version": cat_version},
     55     )

NameError: name 'cat_version' is not defined
```


## Checklist

- [ ] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
