### PR TITLE
Fix issues with frequency translations

### DIFF
--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -30,11 +30,15 @@ __all__ = [
 
 FREQUENCY_TRANSLATIONS = {
     "monthly-averaged-by-hour": "1hr",
-    "monthly-averaged-by-day": "1hr",
+    "monthly-averaged-by-day": "1day",
+    "1hrCM": "1hr",
     "3hrPt": "3hr",
     "6hrPt": "6hr",
     "daily": "1day",
     "day": "1day",
+    "night": "1day",
+    "mon_day_time": "1mon",
+    "mon_night_time": "1mon",
     "mon": "1mon",
     "monthly-averaged": "1mon",
     "monC": "1mon",
@@ -44,6 +48,8 @@ FREQUENCY_TRANSLATIONS = {
     "subhrPt": "subhr",
     "yr": "1yr",
     "yrPt": "1yr",
+    "yrC": "1yr",
+    "na": "fx",
 }
 
 

--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -388,6 +388,11 @@ class CordexTranslator(DefaultTranslator):
         self.set_dispatch(
             input_name="realm", core_colname="realm", func=self._realm_translator
         )
+        self.set_dispatch(
+            input_name="frequency",
+            core_colname="frequency",
+            func=super()._frequency_translator,
+        )
 
     def _realm_translator(self):
         """


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Updates `FREQUENCY_TRANSLATORS` to include new values for `barpa_py18` and `esgf_ref_qv56`, and adds frequency name mapping to `CordexTranslator`.

## Related issue number

Will close #405 .

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

## Notes

- In order to build a new catalog including this additional datastore, you will need to either release a new version of the `access-nri-intake` package, or run the `bin/build_all.sh` script to build a new catalog, using a virtual environment with the most recent (ie. including this PR) version of `access-nri-intake` installed. This can be done by activating the `venv` in `/g/data/xp65/admin/access-nri-intake-catalog/bin/build_all.sh` job.
<!-- End of Translator Change section  -->

<!--
Please add any other relevant info below:
-->

Changes have been confirmed to work with both direct investigation via Jupyter, and by a restricted test catalog build.