### PR TITLE
Update Om2 Builder pattern for '01deg_jra55v140_iaf_cycle2'

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -362,7 +362,7 @@ class AccessOm2Builder(BaseBuilder):
     """Intake-ESM datastore builder for ACCESS-OM2 COSIMA datasets"""
 
     PATTERNS = [
-        rf"^iceh.*\.({PATTERNS_HELPERS['ymd']}|{PATTERNS_HELPERS['ym']})$",  # ACCESS-ESM1.5/OM2/CM2 ice
+        rf"^iceh.*\.({PATTERNS_HELPERS['ymd']}|{PATTERNS_HELPERS['ym']}).*$",  # ACCESS-ESM1.5/OM2/CM2 ice
         rf"^iceh.*\.(\d{{3}})-{PATTERNS_HELPERS['not_multi_digit']}.*",  # ACCESS-OM2 ice
         rf"^ocean.*[_,-](?:ymd|ym|y)_({PATTERNS_HELPERS['ymd']}|{PATTERNS_HELPERS['ym']}|{PATTERNS_HELPERS['y']})(?:$|[_,-]{PATTERNS_HELPERS['not_multi_digit']}.*)",  # ACCESS-OM2 ocean
         r"^ocean.*[^\d]_(\d{2})$",  # A few wierd files in ACCESS-OM2 01deg_jra55v13_ryf9091

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -364,6 +364,11 @@ def test_builder_columns_with_iterables(test_data):
         ),
         (
             builders.AccessOm2Builder,
+            "iceh.1958-02-daily",
+            ("iceh_XXXX_XX_daily", "1958-02", (1, "day")),
+        ),
+        (
+            builders.AccessOm2Builder,
             "iceh.1985-08-31",
             ("iceh_XXXX_XX_XX", "1985-08-31", None),
         ),


### PR DESCRIPTION
## Change Summary

- Allow for some trailing characters in the om2 builder regex patterns.
- Test for this case.

## Related issue number

https://github.com/COSIMA/cosima-recipes/issues/313 : Sea_Ice_Seasonality_Statistics.ipynb requires it.


## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable N/A
