### PR TITLE
Add forum post reminder

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -534,6 +534,10 @@ def build(argv: Sequence[str] | None = None):
 
     _concretize_build(build_base_path, version, catalog_file, catalog_base_path, update)
 
+    print(
+        "*** Build Complete! *** \n If you are happy with the build, please remember to update the forum topic: https://forum.access-hive.org.au/t/access-nri-intake-catalog-a-way-to-find-load-and-share-data-on-gadi/1659/"
+    )
+
 
 def _concretize_build(
     build_base_path: str | Path,


### PR DESCRIPTION
## Change Summary

- Reminder to post on the forum, after a catalog build has been completed. Emitted as part of the job log.


