### PR TITLE
Add more panant experiments (MOM6)

### DIFF
--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 #PBS -P iq82
-#PBS -l storage=gdata/xp65+gdata/ik11+gdata/cj50+gdata/p73+gdata/dk92+gdata/al33+gdata/rr3+gdata/fs38+gdata/oi10+gdata/hq89+gdata/py18+gdata/ig45+gdata/zz63+gdata/rt52+gdata/jk72+gdata/qv56+gdata/ct11
+#PBS -l storage=gdata/xp65+gdata/ik11+gdata/cj50+gdata/p73+gdata/dk92+gdata/al33+gdata/rr3+gdata/fs38+gdata/oi10+gdata/hq89+gdata/py18+gdata/ig45+gdata/zz63+gdata/rt52+gdata/jk72+gdata/qv56+gdata/ct11+gdata/ol01
 #PBS -q normal
 #PBS -W block=false
 #PBS -l walltime=06:00:00

--- a/config/metadata_sources/mom6-panant-0025-zstar-ACCESSyr2-ol01/metadata.yaml
+++ b/config/metadata_sources/mom6-panant-0025-zstar-ACCESSyr2-ol01/metadata.yaml
@@ -1,0 +1,24 @@
+contact: Wilton Aguiar
+email: wilton.aguiar@anu.edu.au
+name: panant-0025-zstar-ACCESSyr2
+experiment_uuid: ac36a25e-835a-4589-9879-c9a47a0924cc
+created: 2025-01-08
+model:
+  - MOM6
+  - SIS2
+nominal_resolution: 
+  - 0.025 degrees
+description: >-
+  0.025 degree (MOM6+SIS2) Pan-Antarctic regional model configuration under 1990-1991 JRA55-do repeat year forcing.
+long_description: >-
+  Simulation of the Pan-Antarctic config (MOM6+SIS2) for a regional domain south of 37S. Forcing at the boundary and initial conditions come from the year 2 of the ACCESS-OM2-01 RYF config (01deg_jra55v13_ryf9091), so that conditions are close to observed.
+url: https://github.com/COSIMA/mom6-panan
+reference: null 
+notes: >-
+keywords:
+  - fortieth
+  - cosima
+  - mom6
+  - ryf
+  - panant
+  - sis2

--- a/config/metadata_sources/mom6-panant-005-zstar-ACCESSyr2-ol01/metadata.yaml
+++ b/config/metadata_sources/mom6-panant-005-zstar-ACCESSyr2-ol01/metadata.yaml
@@ -1,0 +1,24 @@
+contact: Adele Morrison
+email: adele.morrison@anu.edu.au
+name: panant-005-zstar-ACCESSyr2
+experiment_uuid: 24ccb617-a193-4e98-9382-18a736f0262d
+created: 2025-01-08
+model:
+  - MOM6
+  - SIS2
+nominal_resolution: 
+  - 0.05 degrees
+description: >-
+  0.05 degree (MOM6+SIS2) Pan-Antarctic regional model configuration under 1990-1991 JRA55-do repeat year forcing.
+long_description: >-
+  Simulation of the Pan-Antarctic config (MOM6+SIS2) for a regional domain south of 37S. Forcing at the boundary and initial conditions come from the year 2 of the ACCESS-OM2-01 RYF config (01deg_jra55v13_ryf9091), so that conditions are close to observed.
+url: https://github.com/COSIMA/mom6-panan
+reference: null 
+notes: >-
+keywords:
+  - twentieth
+  - cosima
+  - mom6
+  - ryf
+  - panant
+  - sis2

--- a/config/metadata_sources/mom6-panant-01-zstar-ACCESSyr2-ol01/metadata.yaml
+++ b/config/metadata_sources/mom6-panant-01-zstar-ACCESSyr2-ol01/metadata.yaml
@@ -1,0 +1,24 @@
+contact: Adele Morrison
+email: adele.morrison@anu.edu.au
+name: panant-01-zstar-ACCESSyr2
+experiment_uuid: c7e82794-59e8-4923-91c0-337fbdb3ce41
+created: 2023-07-01
+model:
+  - MOM6
+  - SIS2
+nominal_resolution: 
+  - 0.1 degrees
+description: >-
+  0.1 degree (MOM6+SIS2) Pan-Antarctic regional model configuration under 1990-1991 JRA55-do repeat year forcing.
+long_description: >-
+  Simulation of the Pan-Antarctic config (MOM6+SIS2) for a regional domain south of 37S. Forcing at the boundary and initial conditions come from the year 2 of the ACCESS-OM2-01 RYF config (01deg_jra55v13_ryf9091), so that conditions are close to observed.
+url: https://github.com/COSIMA/mom6-panan
+reference: null 
+notes: >-
+keywords:
+  - tenth
+  - cosima
+  - mom6
+  - ryf
+  - panant
+  - sis2

--- a/config/mom6.yaml
+++ b/config/mom6.yaml
@@ -15,3 +15,15 @@ sources:
   - metadata_yaml: /g/data/ik11/outputs/mom6-panan/panant-01-zstar-v13/metadata.yaml
     path:
     - /g/data/ik11/outputs/mom6-panan/panant-01-zstar-v13
+
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/mom6_panant_01_zstar_ACCESS2yr_ol01/metadata.yaml
+    path:
+    - /g/data/ol01/outputs/mom6-panan/panant-01-zstar-ACCESSyr2
+
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/mom6_panant_005_zstar_ACCESS2yr_ol01/metadata.yaml
+    path:
+    - /g/data/ol01/outputs/mom6-panan/panant-005-zstar-ACCESSyr2
+
+  - metadata_yaml: /g/data/xp65/admin/intake/metadata/mom6_panant_0025_zstar_ACCESS2yr_ol01/metadata.yaml
+    path:
+    - /g/data/ol01/outputs/mom6-panan/panant-0025-zstar-ACCESSyr2

--- a/docs/project_list.rst
+++ b/docs/project_list.rst
@@ -6,6 +6,7 @@
 * :code:`ik11`
 * :code:`jk72`
 * :code:`oi10`
+* :code:`ol01`
 * :code:`p73`
 * :code:`py18`
 * :code:`qv56`

--- a/docs/storage_flags.rst
+++ b/docs/storage_flags.rst
@@ -1,3 +1,3 @@
 .. code-block::
 
-   gdata/al33+gdata/cj50+gdata/fs38+gdata/hq89+gdata/ig45+gdata/ik11+gdata/jk72+gdata/oi10+gdata/p73+gdata/py18+gdata/qv56+gdata/rr3+gdata/rt52+gdata/xp65+gdata/zz63
+   gdata/al33+gdata/cj50+gdata/fs38+gdata/hq89+gdata/ig45+gdata/ik11+gdata/jk72+gdata/oi10+gdata/ol01+gdata/p73+gdata/py18+gdata/qv56+gdata/rr3+gdata/rt52+gdata/xp65+gdata/zz63


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Add the `ACCESS2yr` panant experiments to the catalog.

## Related issue number

Closes #420 .

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!-- Delete this section unless you have added a new translator/datastore: -->
- [x] The new translator has been added to `__all__` in `src/access_nri_intake/catalog/translators.py` (N/A)
-  [x] The new datastore has been added to the list of configs in `bin/build_all.sh` and `bin/test_end_to_end.sh`, and the storage flags in both scripts updated, if necessary.
- [x] You have generated a valid `metadata.yaml` for the datastore & placed it in the correct location: eg. `config/metadata_sources/esgf-ref-qv56/metadata.yaml` for the `esgf-ref-qv56` datastore.
- [x] The `metadata.yaml` has been copied to the correct location in `/g/data/xp65/admin/intake` -  for example, `/g/data/xp65/admin/intake/metadata/esgf-ref-qv56/metadata.yaml` for the `esgf-ref-qv56` datastore

## Notes

- In order to build a new catalog including this additional datastore, you will need to either release a new version of the `access-nri-intake` package, or run the `bin/build_all.sh` script to build a new catalog, using a virtual environment with the most recent (ie. including this PR) version of `access-nri-intake` installed. This can be done by activating the `venv` in `/g/data/xp65/admin/access-nri-intake-catalog/bin/build_all.sh` job.
<!-- End of Translator Change section  -->

<!--
Please add any other relevant info below:
-->

Test build successfully added the new experiments.