### PR TITLE
418 fix barpa

### DIFF
--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -46,6 +46,7 @@ FREQUENCY_TRANSLATIONS = {
     "monClim": "1mon",
     "monPt": "1mon",
     "sem": "3mon",
+    "20min": "subhr",
     "subhrPt": "subhr",
     "yr": "1yr",
     "yrPt": "1yr",
@@ -698,7 +699,7 @@ class EsmValToolTranslator(DefaultTranslator):
         }
 
         return self.source.df["table_id"].apply(
-            lambda x: CT11_TABLEID_FREQ_TRANSLATIONS.get(x, x)
+            lambda x: CT11_TABLEID_FREQ_TRANSLATIONS.get(x, "none")
         )
 
 

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -138,7 +138,7 @@ def _add_source_to_catalog(
         getattr(cm, method)(**src_args)
     except Exception as e:  # actually valid for once - it may raise naked Exceptions
         warnings.warn(
-            f"Unable to add {src_args['name']} to catalog - continuing", source=e
+            f"Unable to add {src_args['name']} to catalog - continuing. Error: {str(e)}\n{traceback.format_exc()}"
         )
 
 


### PR DESCRIPTION
## Change Summary

- Fix translator for Barpa by adding a '20min' translation to the big `FREQUENCY_TRANSLATIONS` list
- Change translator for `EsmValToolTranslator` default to "none" - was just returning the name of frequencys that weren't found, which was realm derived & caused the issue.
- I've changed the warning in the main catalog build script - it wasn't emitting the full warning properly. This might negate the need for the pymalloctraceback stuff @marc-white ?

## Related issue number

Closes #418 

## Checklist

- [ ] Unit tests for the changes exist N/A?
- [x] Tests pass on CI

