### PR TITLE
459: Add OM3 patterns for `AccessOm3Builder`

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -283,7 +283,12 @@ class BaseBuilder(Builder):
             if match:
                 # FIXME switch to using named group for timestamp
                 # Loop over all found groups and redact
-                timestamp = match.group(1)
+
+                if not match.groups():
+                    timestamp = "Unknown"
+                else:
+                    timestamp = match.group(1)
+
                 for grp in match.groups():
                     if grp is not None:
                         redaction = re.sub(r"\d", redaction_fill, grp)
@@ -425,6 +430,7 @@ class AccessOm3Builder(BaseBuilder):
 
     PATTERNS = [
         rf"[^\.]*\.{PATTERNS_HELPERS['om3_components']}\..*?({PATTERNS_HELPERS['ymds']}|{PATTERNS_HELPERS['ymd']}|{PATTERNS_HELPERS['ym']}|{PATTERNS_HELPERS['y']})(?:$|{PATTERNS_HELPERS['not_multi_digit']})",  # ACCESS-OM3
+        "ocean_month(?:_z)?",
     ]
 
     def __init__(self, path, **kwargs):

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -457,6 +457,24 @@ def test_builder_columns_with_iterables(test_data):
         # Example ACCESS-OM3 filenames
         (
             builders.AccessOm3Builder,
+            "ocean_month",
+            (
+                "ocean_month",
+                "Unknown",
+                (1, "mon"),
+            ),
+        ),
+        (
+            builders.AccessOm3Builder,
+            "ocean_month_z",
+            (
+                "ocean_month_z",
+                "Unknown",
+                (1, "mon"),
+            ),
+        ),
+        (
+            builders.AccessOm3Builder,
             "access-om3.ww3.hi.1958-01-02-00000",
             (
                 "access_om3_ww3_hi_XXXX_XX_XX_XXXXX",


### PR DESCRIPTION
## Change Summary

- Add patterns for `ocean_month.nc` and `ocean_month_z.nc`
- Add tests
- Set timestamp to `"Unknown"` for these cases.

## Related issue number

#459 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
