### PR TITLE
464 save invalid asset list

### DIFF
--- a/src/access_nri_intake/experiment/main.py
+++ b/src/access_nri_intake/experiment/main.py
@@ -1,5 +1,6 @@
 import itertools
 import warnings
+from datetime import datetime
 from pathlib import Path
 
 import intake
@@ -131,9 +132,14 @@ def use_datastore(
         )
 
         _invalid_assetlist: pd.DataFrame = builder_instance.invalid_assets
-        import pdb
-
-        pdb.set_trace()
+        if not _invalid_assetlist.empty:
+            invalid_asset_fname = f"{datastore_name}-invalid-assets-{datetime.now().strftime('%Y%m%d-%H%M%S')}.csv"
+            invalid_asset_path = catalog_dir / invalid_asset_fname
+            _invalid_assetlist.to_csv(invalid_asset_path, index=False)
+            print(
+                f"{f_warn}Some assets were not included in the datastore due to errors. "
+                f"Please check {f_path}{invalid_asset_path}{f_warn} for details.{f_reset}"
+            )
 
         print(
             f"{f_info}Hashing catalog to prevent unnecessary rebuilds.\nThis may take some time...{f_reset}"

--- a/src/access_nri_intake/experiment/main.py
+++ b/src/access_nri_intake/experiment/main.py
@@ -3,6 +3,7 @@ import warnings
 from pathlib import Path
 
 import intake
+import pandas as pd
 from intake_esm import esm_datastore
 
 from ..source.builders import Builder
@@ -128,6 +129,11 @@ def use_datastore(
             or f"esm_datastore for the model output in '{str(experiment_dir)}'",
             directory=str(catalog_dir),
         )
+
+        _invalid_assetlist: pd.DataFrame = builder_instance.invalid_assets
+        import pdb
+
+        pdb.set_trace()
 
         print(
             f"{f_info}Hashing catalog to prevent unnecessary rebuilds.\nThis may take some time...{f_reset}"


### PR DESCRIPTION
## Change Summary

- Save out the `Builder.invalid_Assets` dataframe into a CSV, if there were any.

## Related issue number

Closes #464. Might go some way towards addressing #344.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
