### PR TITLE
Add `valid_assets` property to `BaseBuilder` class

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -357,6 +357,23 @@ class BaseBuilder(Builder):
 
         return output_ncfile
 
+    @property
+    def valid_assets(self) -> list[str]:
+        """
+        Return the list of valid assets that have been parsed and validated
+        """
+        if not self.assets:
+            raise ValueError(
+                "asset list provided is None. Please run `.get_assets()` first"
+            )
+
+        if self.invalid_assets.empty:
+            return self.assets
+
+        invalid_assetlist = self.invalid_assets["INVALID_ASSET"].tolist()
+
+        return [asset for asset in self.assets if asset not in invalid_assetlist]
+
 
 class AccessOm2Builder(BaseBuilder):
     """Intake-ESM datastore builder for ACCESS-OM2 COSIMA datasets"""

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -52,6 +52,9 @@ def test_builder_build(
     path = [str(test_data / Path(basedir)) for basedir in basedirs]
     builder = Builder(path, **kwargs)
 
+    with pytest.raises(ValueError, match="asset list provided is None"):
+        builder.valid_assets
+
     builder.get_assets()
     assert isinstance(builder.assets, list)
     assert len(builder.assets) == num_assets
@@ -69,6 +72,8 @@ def test_builder_build(
     )
     assert len(cat.df) == num_valid_assets
     assert len(cat) == num_datasets
+
+    assert len(builder.valid_assets) == num_valid_assets
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

- Add a property to `BaseBuilder` to track the valid assets without the user having to construct it manually every time they want it.


## Related issue number

Lays some groundwork for #344 , along with #465 .

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
