### PR TITLE
Updated AUS2200 datastore path

### DIFF
--- a/config/aus2200.yaml
+++ b/config/aus2200.yaml
@@ -6,4 +6,4 @@ sources:
 
   - metadata_yaml: /g/data/xp65/admin/intake/metadata/aus2200_bs94/metadata.yaml
     path:
-    - /g/data/bs94/catalog/.prerelease/v2/esm/catalog.json
+    - /g/data/bs94/catalog/v2/esm/catalog.json


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

AUS2200 datastore path has been updated to `/g/data/bs94/catalog/v2/esm/catalog.json`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Related to #319 and #477 

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->