### PR TITLE
Cmip6Builder Ensemble bugfix

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -972,7 +972,7 @@ class Cmip6Builder(BaseBuilder):
     ]
     # PATTERNS is mostly unused here - we get the realm from the metadata. Only
     # using it to match on file names here & should be refactored to be removed. TODO
-    ensemble: bool = False
+    ensemble: bool = True
 
     def __init__(self, path, ensemble: bool, **kwargs):
         """
@@ -1012,6 +1012,7 @@ class Cmip6Builder(BaseBuilder):
                     "attribute_name": "member",
                 },
             ]
+            kwargs["groupby_attrs"] += ["member"]
 
         Cmip6Builder.ensemble = ensemble
 
@@ -1050,6 +1051,6 @@ class Cmip6Builder(BaseBuilder):
                         f"Cannot determine member for file {file} - "
                         "realization_index attribute missing"
                     )
-                ncinfo_dict["member"] = f"r{int(member_id):03d}"
+                ncinfo_dict["member"] = f"r{int(member_id)}"
 
         return ncinfo_dict

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -973,7 +973,7 @@ class Cmip6Builder(BaseBuilder):
     # PATTERNS is mostly unused here - we get the realm from the metadata. Only
     # using it to match on file names here & should be refactored to be removed. TODO
 
-    def __init__(self, path, **kwargs):
+    def __init__(self, path, ensemble: bool, **kwargs):
         """
         Initialise a Cmip6Builder
 
@@ -1003,6 +1003,14 @@ class Cmip6Builder(BaseBuilder):
                 },
             ],
         )
+
+        if ensemble:
+            kwargs["aggregations"] += [
+                {
+                    "type": "join_new",
+                    "attribute_name": "member",
+                },
+            ]
 
         super().__init__(**kwargs)
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -35,7 +35,8 @@ from access_nri_intake.source.utils import _NCFileInfo
         (["roms"], "ROMSBuilder", {}, 4, 4, 1),
         (["access-esm1-6"], "AccessEsm16Builder", {"ensemble": False}, 20, 20, 7),
         (["woa"], "WoaBuilder", {}, 7, 7, 2),
-        (["cmip6"], "Cmip6Builder", {}, 74, 73, 14),
+        (["cmip6"], "Cmip6Builder", {"ensemble": False}, 74, 73, 14),
+        (["cmip6"], "Cmip6Builder", {"ensemble": True}, 74, 73, 14),
     ],
 )
 def test_builder_build(

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -36,7 +36,7 @@ from access_nri_intake.source.utils import _NCFileInfo
         (["access-esm1-6"], "AccessEsm16Builder", {"ensemble": False}, 20, 20, 7),
         (["woa"], "WoaBuilder", {}, 7, 7, 2),
         (["cmip6"], "Cmip6Builder", {"ensemble": False}, 74, 73, 14),
-        (["cmip6"], "Cmip6Builder", {"ensemble": True}, 74, 73, 14),
+        (["cmip6"], "Cmip6Builder", {"ensemble": True}, 74, 73, 31),
     ],
 )
 def test_builder_build(
@@ -286,6 +286,13 @@ def test_builder_build(
             "Cmip6Builder",
             "atmos",
             None,
+            "atmos.1mon.bnds:2.lat:2.lon:2",
+        ),
+        (
+            "cmip6/uas_Amon_ACCESS-ESM1-5_historical_r9i1p1f1_1981-2000_r360x180.nc",
+            "Cmip6Builder",
+            "atmos",
+            "r9",
             "atmos.1mon.bnds:2.lat:2.lon:2",
         ),
     ],


### PR DESCRIPTION
## Change Summary

Fixes to address issues [on this forum post](https://forum.access-hive.org.au/t/building-intake-catalog-parser-returns-no-valid-assets-error/5320/11)

TLDR; updates the `Cmip6Builder` to separate datasets on `member` if the ensemble kwarg is passed as true. Reasoning being that ensemble runs of a model will all be on the same grid (and so mergeable), but should not be merged as part of the same dataset.

## Related issue number

None, but see forum post

## Please add any other relevant info below:

This is something we never really noticed as an issue before, but I think the changes to mergeability based `file_id` have created it. This will probably also need to be updated in the `AccessEsm15Builder`.

@dougiesquire can you confirm I'm barking up the right tree with the intent of the ensemble kwarg here?