### PR TITLE
Fix translator tests for Aus2200 so we catch any dodgy frequencies

### DIFF
--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -773,3 +773,27 @@ class Aus2200Translator(DefaultTranslator):
             core_colname="variable",
             func=super()._variable_translator,
         )
+
+        self.set_dispatch(
+            input_name="frequency",
+            core_colname="frequency",
+            func=self._frequency_translator,
+        )
+
+    @tuplify_series
+    @trace_failure
+    def _frequency_translator(self):
+        """
+        Return frequency, fixing a few issues
+        TODO: It would be preferable to add 10min, etc. to the data spec.
+        """
+
+        AUS200_FREQ_TRANSLATIONS = {
+            "10min": "subhr",
+            "1hrPlev": "1hr",
+            "6hrPlev": "6hr",
+        }
+
+        return self.source.df["frequency"].apply(
+            lambda x: AUS200_FREQ_TRANSLATIONS.get(x, x)
+        )

--- a/src/access_nri_intake/catalog/translators.py
+++ b/src/access_nri_intake/catalog/translators.py
@@ -704,43 +704,6 @@ class EsmValToolTranslator(DefaultTranslator):
         )
 
 
-@dataclass
-class _DispatchKeys:
-    """
-    Data class to store the keys for the dispatch dictionary in the Translator classes
-    """
-
-    model: str | None = None
-    realm: str | None = None
-    frequency: str | None = None
-    variable: str | None = None
-
-
-def _cmip_realm_translator(series) -> pd.Series:
-    """
-    Return realm from CMIP realm metadata, fixing some issues. This function takes
-    a series of strings and returns a series of tuples as there are sometimes multiple
-    realms per cmip asset
-    """
-
-    def _translate(string: str) -> tuple[str, ...]:
-        translations = {
-            "na": "none",
-            "landonly": "land",
-            "ocnBgChem": "ocnBgchem",
-            "seaice": "seaIce",
-        }
-
-        raw_realms = string.split(" ")
-        realms = set()
-        for realm in raw_realms:
-            realm = translations.get(realm, realm)
-            realms |= {realm}
-        return tuple(realms)
-
-    return series.apply(lambda string: _translate(string))
-
-
 class Aus2200Translator(DefaultTranslator):
     """
     AUS2200 Translator for translating metadata from the NCI AUS2200 intake datastores.
@@ -797,3 +760,40 @@ class Aus2200Translator(DefaultTranslator):
         return self.source.df["frequency"].apply(
             lambda x: AUS200_FREQ_TRANSLATIONS.get(x, x)
         )
+
+
+@dataclass
+class _DispatchKeys:
+    """
+    Data class to store the keys for the dispatch dictionary in the Translator classes
+    """
+
+    model: str | None = None
+    realm: str | None = None
+    frequency: str | None = None
+    variable: str | None = None
+
+
+def _cmip_realm_translator(series) -> pd.Series:
+    """
+    Return realm from CMIP realm metadata, fixing some issues. This function takes
+    a series of strings and returns a series of tuples as there are sometimes multiple
+    realms per cmip asset
+    """
+
+    def _translate(string: str) -> tuple[str, ...]:
+        translations = {
+            "na": "none",
+            "landonly": "land",
+            "ocnBgChem": "ocnBgchem",
+            "seaice": "seaIce",
+        }
+
+        raw_realms = string.split(" ")
+        realms = set()
+        for realm in raw_realms:
+            realm = translations.get(realm, realm)
+            realms |= {realm}
+        return tuple(realms)
+
+    return series.apply(lambda string: _translate(string))

--- a/tests/data/esm_datastore/aus2200-bs94.csv
+++ b/tests/data/esm_datastore/aus2200-bs94.csv
@@ -22,3 +22,6 @@ path,file_type,realm,model_id,experiment_id,frequency,variable_id,version,time_r
 /g/data/bs94/AUS2200/ecoastlow-smooth/v1-0/1hr/pfull/pfull_AUS2200_ecoastlow-smooth_1hrPt_201606031900-201606040000.nc,f,atmos,AUS2200,ecoastlow-smooth,1hr,pfull,v1-0,201606031900-201606040000
 /g/data/bs94/AUS2200/coralsea-sstreduced/v1-0/10min/vas/vas_AUS2200_flood22-reducedsst_subhrPt_20220302012000-20220303011000.nc,f,atmos,AUS2200,coralsea-sstreduced,10min,vas,v1-0,20220302012000-20220303011000
 /g/data/bs94/AUS2200/mjo-neutral2013/v1-0/1hr/mrso/mrso_AUS2200_mjo-neutral_1hrPt_201301180100-201301190000.nc,f,land,AUS2200,mjo-neutral2013,1hr,mrso,v1-0,201301180100-201301190000
+/g/data/bs94/AUS2200/mjo-lanina2018/v1-0/1hrPlev/ta/ta_AUS2200_mjo-lanina_1hrPt_201802040100-201802041200.nc,f,atmos,AUS2200,mjo-lanina2018,1hrPlev,ta,v1-0,201802040100-201802041200
+/g/data/bs94/AUS2200/coralsea-sstreduced/v1-0/6hrPlev/zg/zg_AUS2200_coralsea-sstreduced_6hrPt_202203020100-202203021900.nc,f,atmos,AUS2200,coralsea-sstreduced,6hrPlev,zg,v1-0,202203020100-202203021900
+/g/data/bs94/AUS2200/mjo-lanina2018/v1-0/10min/pralsns/pralsns_AUS2200_mjo-lanina_subhr_20180209000500-20180209235500.nc,f,atmos,AUS2200,mjo-lanina2018,10min,pralsns,v1-0,20180209000500-20180209235500

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -351,9 +351,9 @@ def test_CcamTranslator(test_data, groupby, n_entries):
 @pytest.mark.parametrize(
     "groupby, n_entries",
     [
-        (None, 23),
+        (None, 26),
         (["variable"], 23),
-        (["frequency"], 4),
+        (["frequency"], 3),
         (["model"], 1),
         (["realm"], 2),
     ],


### PR DESCRIPTION
## Change Summary

- Translate `10min` => `subhr`, `1hrPlev` => `1hr`, `6hrPlev` => `6hr`.
- Add test cases.

These are all the nonstandard frequencies in Aus2200: 
```python
>>> df = pd.read_csv("access-regional-bs94.csv.gz")
>>> df.columns
Index(['path', 'file_type', 'realm', 'model_id', 'experiment_id', 'frequency',
       'variable_id', 'version', 'time_range'],
      dtype='object')
>>> df.frequency.unique()
array(['10min', '1hrPlev', '1hr', '6hrPlev', 'fx', '3hr'], dtype=object)
```
## Related issue number

N/A

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
