### PR TITLE
Build mainline catalog with parquet

### DIFF
--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -7,7 +7,7 @@ dependencies:
   - python==3.10
   - access-py-telemetry>=0.1.6
   - cftime
-  - accessnri::ecgtools-access
+  - accessnri::ecgtools-access>=2025.10.7
   - frozendict
   - intake>=2.0.0
   - intake-dataframe-catalog>=0.3.1

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -7,7 +7,7 @@ dependencies:
   - python==3.11
   - access-py-telemetry>=0.1.6
   - cftime
-  - accessnri::ecgtools-access
+  - accessnri::ecgtools-access>=2025.10.7
   - frozendict
   - intake>=2.0.0
   - intake-dataframe-catalog>=0.3.1

--- a/ci/environment-3.12.yml
+++ b/ci/environment-3.12.yml
@@ -7,7 +7,7 @@ dependencies:
   - python==3.12
   - access-py-telemetry>=0.1.6
   - cftime
-  - accessnri::ecgtools-access
+  - accessnri::ecgtools-access>=2025.10.7
   - frozendict
   - intake>=2.0.0
   - intake-dataframe-catalog>=0.3.1

--- a/ci/environment-3.13.yml
+++ b/ci/environment-3.13.yml
@@ -7,7 +7,7 @@ dependencies:
   - python==3.13
   - access-py-telemetry>=0.1.6
   - cftime
-  - accessnri::ecgtools-access
+  - accessnri::ecgtools-access>=2025.10.7
   - frozendict
   - intake>=2.0.0
   - intake-dataframe-catalog>=0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 dependencies = [
     "cftime",
-    "ecgtools-access",
+    "ecgtools-access>=2025.10.7",
     "frozendict",
     "intake>=2.0.0",
     "intake-dataframe-catalog>=0.3.1",

--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -125,7 +125,7 @@ class CatalogManager:
             description,
             metadata,
             translator,
-            columns_with_iterables=list(builder.columns_with_iterables),
+            # No longer need columns with iterables, natively handled by parquet
         )
 
         self._add()

--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -114,7 +114,9 @@ class CatalogManager:
                 )
 
         builder = builder(path, **kwargs).build()
-        builder.save(name=name, description=description, directory=directory)
+        builder.save(
+            name=name, description=description, directory=directory, use_parquet=True
+        )
 
         self.source, self.source_metadata = _open_and_translate(
             str(json_file),

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -139,7 +139,20 @@ class BaseBuilder(Builder):
         self._parse()
         return self
 
-    def _save(self, name: str, description: str, directory: str | None):
+    def _save(
+        self, name: str, description: str, directory: str | None, use_parquet: bool
+    ) -> None:
+        if use_parquet:
+            kwargs = {
+                "file_format": "parquet",
+                "write_kwargs": {"compression": "snappy"},
+            }
+        else:
+            kwargs = {
+                "file_format": "csv",
+                "write_kwargs": {"compression": None},
+            }
+
         super().save(
             name=name,
             path_column_name=PATH_COLUMN,
@@ -150,11 +163,16 @@ class BaseBuilder(Builder):
             esmcat_version="0.0.1",
             description=description,
             directory=directory,
-            catalog_type="file",
-            to_csv_kwargs={"compression": None},
+            **kwargs,
         )
 
-    def save(self, name: str, description: str, directory: str | None = None) -> None:
+    def save(
+        self,
+        name: str,
+        description: str,
+        directory: str | None = None,
+        use_parquet: bool = False,
+    ) -> None:
         """
         Save datastore contents to a file.
 
@@ -166,6 +184,10 @@ class BaseBuilder(Builder):
             Detailed multi-line description of the collection.
         directory: str, optional
             The directory to save the datastore to. If None, use the current directory.
+        use_parquet: bool, optional
+            Whether to save the datastore as a parquet file. Defaults to False,
+            which saves as a CSV file. Parquet is both faster and saves space, but
+            unlike CSV is not human-readable.
         """
 
         if self.df.empty:
@@ -173,7 +195,7 @@ class BaseBuilder(Builder):
                 "Intake-ESM datastore has not yet been built. Please run `.build()` first"
             )
 
-        self._save(name, description, directory)
+        self._save(name, description, directory, use_parquet)
 
     @classmethod
     def _parser_catch_invalid(cls, file: str) -> dict:


### PR DESCRIPTION
## Change Summary

- Add a `use_parquet` flag to BaseBuilder, set it to False by default so user generated catalogues still use `csv` files - being human readable is probably helpful in those cases.
- Remove the `columns_with_iterables` specification from the `CatalogManager` class - this is no longer needed as the parquet files contain that schema information on their own.
- Set the parquet files to use snappy compression - no particular reason here other than balance of speed/size.

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
