### PR TITLE
Take 2: Add configurable build via parquet (semi reverts #535, configurable, which reverted #518)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -80,7 +80,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl
@@ -120,6 +121,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/e9/704bbc08aace64fee536e4c2c20f63f64f6fdbad72938c5ed46c9723a9f1/pdbpp-0.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/9a/632e58ec89a32738cabfd9ec418f0e9898a2b4719afc581f07c04a05e3c9/pillow-12.1.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ab/8a/6f56af7e535c34c95decc8654786bfce4632ba32817dc2f8bad18571ef9a/polars-1.32.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -233,7 +235,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl
@@ -273,6 +276,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/e9/704bbc08aace64fee536e4c2c20f63f64f6fdbad72938c5ed46c9723a9f1/pdbpp-0.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/34/583420a1b55e715937a85bd48c5c0991598247a1fd2eb5423188e765ea02/pillow-12.1.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/e9/88f5332001b9dd5c8e0a4fab51015f740e01715a081c41bc0f7ad2bf76a5/polars-1.32.3-cp39-abi3-macosx_11_0_arm64.whl
@@ -386,7 +390,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl
@@ -426,6 +431,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/e9/704bbc08aace64fee536e4c2c20f63f64f6fdbad72938c5ed46c9723a9f1/pdbpp-0.11.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/07/74a9d941fa45c90a0d9465098fe1ec85de3e2afbdc15cc4766622d516056/pillow-12.1.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c8/226953cda6cf9ae63aa9714d396a9138029e31db3c504c15d6711b618f8f/polars-1.32.3-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/87/77cc11c7a9ea9fd05503def69e3d18605852cd0d4b0d3b8f15bbeb3ef1d1/pooch-1.8.2-py3-none-any.whl
@@ -545,7 +551,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/87/45/ca760deab4de448e6c0e3860fc187bcc49216eabda379f6ce68065158843/distributed-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
@@ -692,7 +698,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/87/45/ca760deab4de448e6c0e3860fc187bcc49216eabda379f6ce68065158843/distributed-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
@@ -840,7 +846,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/87/45/ca760deab4de448e6c0e3860fc187bcc49216eabda379f6ce68065158843/distributed-2025.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
@@ -1004,7 +1010,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -1152,7 +1158,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -1301,7 +1307,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -1466,7 +1472,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -1612,7 +1618,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -1759,7 +1765,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -1920,7 +1926,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -2069,7 +2075,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -2219,7 +2225,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/9e1dde8d88806d320e6807756cfd0ecd7951eb5917485ff5755f34caf149/ecgtools_access-2025.10.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/a7/af33584fa6d17b911cfaba460efd3409cb5dd47083c181a4fdfec4bef840/fastlite-0.2.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/45/4aa502bbda9b63c792463c3466a2c5ef3c0830935f81906043f66b2b6c74/fastprogress-1.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
@@ -2335,8 +2341,8 @@ packages:
   timestamp: 1650670423406
 - pypi: ./
   name: access-nri-intake
-  version: 1.4.1+29.g1868109
-  sha256: ece505402f7e02f75b31ec1c60023c533e649f9e335ecc1fbfa2b2e252b30fde
+  version: 1.4.1+31.g3549762.dirty
+  sha256: d1ab25c29f6405b1e8c0add5ba90ca16ccd656e0e753fd688a3099321b408da0
   requires_dist:
   - cftime
   - ecgtools-access
@@ -3455,10 +3461,23 @@ packages:
   - littleutils ; extra == 'tests'
   - rich ; python_full_version >= '3.11' and extra == 'tests'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/84/f8/78832c84a957a01a332612ea6ee5a34f63690737000bf4f90995dcca367d/fastcore-1.11.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl
+  name: fancycompleter
+  version: 0.11.1
+  sha256: 44243d7fab37087208ca5acacf8f74c0aa4d733d04d593857873af7513cdf8a6
+  requires_dist:
+  - pyreadline3 ; python_full_version < '3.13' and sys_platform == 'win32'
+  - pyrepl>=0.11.3 ; python_full_version < '3.13'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - ruff==0.11.8 ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - fancycompleter[tests] ; extra == 'dev'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/a4/d2/8fdcb8d7c41cb3e5c6716ccd24ef9b4f600a210f0ff4e28305c6a9cc491f/fastcore-1.11.4-py3-none-any.whl
   name: fastcore
-  version: 1.11.3
-  sha256: 998825f8f69c44ab16a156bb60e9a6d0988f3e8aa5b2459ec95289b520cf1c0b
+  version: 1.11.4
+  sha256: eaf673c80a07dc4da3996ab599af501b09425136abdb63c0df8f3172e4939c5b
   requires_dist:
   - packaging
   - numpy ; extra == 'dev'
@@ -6786,6 +6805,17 @@ packages:
   - pyzmq ; extra == 'complete'
   - blosc ; extra == 'complete'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/99/e9/704bbc08aace64fee536e4c2c20f63f64f6fdbad72938c5ed46c9723a9f1/pdbpp-0.11.7-py3-none-any.whl
+  name: pdbpp
+  version: 0.11.7
+  sha256: 51916b63693898cf4881b36b4501c83947758d73f582f1f84893662b163bdb75
+  requires_dist:
+  - fancycompleter>=0.11.0
+  - pygments
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - ipython ; extra == 'testing'
+  - pexpect ; extra == 'testing'
 - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
   name: pexpect
   version: 4.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ test-py313 = { features = ["py313", "test"] }
 
 [tool.pixi.feature.dev.pypi-dependencies]
 access_nri_intake = { path = ".", editable = true }
+pdbpp = ">=0.11.7,<0.12"
 
 [tool.pixi.feature.dev.dependencies]
 pre-commit = ">=4.2.0,<5"
@@ -161,7 +162,7 @@ pre-commit = { cmd = "pre-commit run --all-files && pixi lock", description = "R
 dump-conda-env = { cmd = "pixi workspace export conda-environment --name access-nri-intake-test > env.yml", description = "Dump conda environment to env.yml" }
 
 [tool.pixi.feature.test.pypi-dependencies]
-access_nri_intake = { path = ".", editable = false } 
+access_nri_intake = { path = ".", editable = false }
 
 [tool.pixi.feature.test.dependencies]
 pytest = ">=8.4.1,<9"

--- a/src/access_nri_intake/catalog/manager.py
+++ b/src/access_nri_intake/catalog/manager.py
@@ -32,7 +32,7 @@ class CatalogManager:
     Add/update intake sources in an intake-dataframe-catalog like the ACCESS-NRI catalog
     """
 
-    def __init__(self, path: Path | str):
+    def __init__(self, path: Path | str, use_parquet: bool = False):
         """
         Initialise a CatalogManager instance to add/update intake sources in a
         intake-dataframe-catalog like the ACCESS-NRI catalog
@@ -41,12 +41,21 @@ class CatalogManager:
         ----------
         path: str
             The path to the intake-dataframe-catalog
+        use_parquet: bool
+            Whether to use parquet files instead of csv files. This will also save version info into
+            the `parameters::version_pq` namespace, allowing us to separately track parquet & csv
+            catalog versions, maintaining backwards compatibility with existing catalogs.
         """
         path = Path(path)
 
         self.path = str(path)
+        self.use_parquet = use_parquet
 
         self.mode = "a" if path.exists() else "w"
+
+        columns_with_iterables = (
+            COLUMNS_WITH_ITERABLES if not Path.suffix == ".parquet" else None
+        )
 
         try:
             self.dfcat = DfFileCatalog(
@@ -54,7 +63,7 @@ class CatalogManager:
                 yaml_column=YAML_COLUMN,
                 name_column=NAME_COLUMN,
                 mode=self.mode,
-                columns_with_iterables=COLUMNS_WITH_ITERABLES,
+                columns_with_iterables=columns_with_iterables,
             )
         except (EmptyDataError, DfFileCatalogError) as e:
             raise Exception(str(e) + f": {self.path}") from e
@@ -114,17 +123,27 @@ class CatalogManager:
                 )
 
         builder = builder(path, **kwargs).build()
-        builder.save(name=name, description=description, directory=directory)
+        builder.save(
+            name=name,
+            description=description,
+            directory=directory,
+            use_parquet=self.use_parquet,
+        )
 
-        self.source, self.source_metadata = _open_and_translate(
-            str(json_file),
-            "esm_datastore",
-            name,
-            description,
-            metadata,
-            translator,
+        open_translate_kwargs = dict(
+            file=str(json_file),
+            driver="esm_datastore",
+            name=name,
+            description=description,
+            metadata=metadata,
+            translator=translator,
             columns_with_iterables=list(builder.columns_with_iterables),
         )
+        if self.use_parquet:
+            # Don't need to specify columns_with_iterables for parquet - serialised into format
+            open_translate_kwargs.pop("columns_with_iterables")
+
+        self.source, self.source_metadata = _open_and_translate(**open_translate_kwargs)
 
         self._add()
 

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -491,7 +491,7 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
     parser.add_argument(
         "--catalog_file",
         type=str,
-        default="metacatalog.csv",
+        default=None,
         help="The name of the intake-dataframe-catalog. Defaults to 'metacatalog.csv' if `use_parquet` is False, or `metacatalog.parquet` if `use_parquet` is True",
     )
 
@@ -539,6 +539,9 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
     update = not args.no_update
     concretize = not args.no_concretize
     use_parquet = args.use_parquet
+
+    if catalog_file is None:
+        catalog_file = "metacatalog.parquet" if use_parquet else "metacatalog.csv"
 
     if not version.startswith("v"):
         version = f"v{version}"

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -12,6 +12,7 @@ import traceback
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any, Literal
 
 import jsonschema
 import polars as pl
@@ -29,6 +30,8 @@ from .source import builders
 from .utils import _can_be_array, get_catalog_fp, load_metadata_yaml
 
 STORAGE_FLAG_PATTERN = "gdata/[a-z]{1,2}[0-9]{1,2}"
+
+T_catname = Literal["access_nri", "access_nri_pq"]
 
 
 class MetadataCheckError(Exception):
@@ -246,24 +249,26 @@ def _write_catalog_yaml(
     storage_flags: str,
     catalog_file: str,
     version: str,
-) -> dict:
+) -> dict[str, Any]:
     """
     Write the catalog details out to YAML.
     """
+    cat_name: T_catname = "access_nri" if not cm.use_parquet else "access_nri_pq"
+
     cat = cm.dfcat
-    cat.name = "access_nri"
+    cat.name = cat_name
     cat.description = "ACCESS-NRI intake catalog"
     yaml_dict = yaml.safe_load(cat.yaml())
 
-    yaml_dict["sources"]["access_nri"]["args"]["path"] = str(
+    yaml_dict["sources"][cat_name]["args"]["path"] = str(
         Path(build_base_path) / "{{version}}" / catalog_file
     )
-    yaml_dict["sources"]["access_nri"]["args"]["mode"] = "r"
-    yaml_dict["sources"]["access_nri"]["metadata"] = {
+    yaml_dict["sources"][cat_name]["args"]["mode"] = "r"
+    yaml_dict["sources"][cat_name]["metadata"] = {
         "version": "{{version}}",
         "storage": storage_flags,
     }
-    yaml_dict["sources"]["access_nri"]["parameters"] = {
+    yaml_dict["sources"][cat_name]["parameters"] = {
         "version": {"description": "Catalog version", "type": "str", "default": version}
     }
 
@@ -277,6 +282,7 @@ def _compute_previous_versions(
     catalog_base_path: str | Path,
     build_base_path: Path,
     version: str,
+    use_parquet: bool = False,
 ) -> dict:
     """Calculate previous version information for a new catalog build.
 
@@ -290,6 +296,8 @@ def _compute_previous_versions(
         The catalog build base path.
     version : str
         The current version of the catalog (this has yet to enter `yaml_dict`).
+    use_pq : bool
+        Whether the parquet catalog is being built. Defaults to False
 
     Returns
     -------
@@ -309,9 +317,17 @@ def _compute_previous_versions(
       - If existing catalogs are otherwise compatible with the new catalog, their
         min and max versions will be incorporated in with the new catalog and the
         existing catalog.yaml will be overwritten.
+    - If we have switched from csv to parquet or vice versa, the existing catalog
+        will be retained as-is, and the new catalog will be added alongside it.
+    - Whether we update `access_nri` or `access_nri_pq` is determined by the
+    `use_parquet` flag. The other catalog will be retained as-is.
+    TODO: Storage flag combination probably needs updating, but implement in a
+    separate PR to manage complexity.
     """
     cat_loc = get_catalog_fp(basepath=catalog_base_path)
     existing_cat = Path(cat_loc).exists()
+
+    cat_name: T_catname = "access_nri" if not use_parquet else "access_nri_pq"
 
     # See if there's an existing catalog
     if existing_cat:
@@ -323,53 +339,60 @@ def _compute_previous_versions(
         # of each dict path):
         # - args (all parts - mode should never change)
         # - driver
-
-        args_new, args_old = (
-            yaml_dict["sources"]["access_nri"]["args"],
-            yaml_old["sources"]["access_nri"]["args"],
-        )
-        driver_new, driver_old = (
-            yaml_dict["sources"]["access_nri"]["driver"],
-            yaml_old["sources"]["access_nri"]["driver"],
-        )
-        vmin_old, vmax_old = (
-            yaml_old["sources"]["access_nri"]["parameters"]["version"].get("min"),
-            yaml_old["sources"]["access_nri"]["parameters"]["version"].get("max"),
-        )
-        storage_new, storage_old = (
-            yaml_dict["sources"]["access_nri"]["metadata"]["storage"],
-            yaml_old["sources"]["access_nri"]["metadata"]["storage"],
-        )
-
-        if (
-            (args_new != args_old or driver_new != driver_old)
-            and vmin_old is not None
-            and vmax_old is not None
-        ):
-            # Move the old catalog out of the way
-            # New catalog.yaml will have restricted version bounds
-            if vmin_old == vmax_old:
-                vers_str = vmin_old
-            else:
-                vers_str = f"{vmin_old}-{vmax_old}"
-            Path(cat_loc).rename(Path(cat_loc).parent / f"catalog-{vers_str}.yaml")
-            yaml_dict = _set_catalog_yaml_version_bounds(yaml_dict, version, version)
-        elif storage_new != storage_old:
-            yaml_dict["sources"]["access_nri"]["metadata"]["storage"] = (
-                _combine_storage_flags(storage_new, storage_old)
+        if not yaml_old["sources"].get(cat_name):
+            alt_name = "access_nri" if cat_name == "access_nri_pq" else "access_nri_pq"
+            vmin_old, vmax_old = None, None
+            yaml_dict["sources"][alt_name] = yaml_old["sources"][alt_name]
+        else:
+            args_new, args_old = (
+                yaml_dict["sources"][cat_name]["args"],
+                yaml_old["sources"][cat_name]["args"],
+            )
+            driver_new, driver_old = (
+                yaml_dict["sources"][cat_name]["driver"],
+                yaml_old["sources"][cat_name]["driver"],
+            )
+            vmin_old, vmax_old = (
+                yaml_old["sources"][cat_name]["parameters"]["version"].get("min"),
+                yaml_old["sources"][cat_name]["parameters"]["version"].get("max"),
+            )
+            storage_new, storage_old = (
+                yaml_dict["sources"][cat_name]["metadata"]["storage"],
+                yaml_old["sources"][cat_name]["metadata"]["storage"],
             )
 
-        # Set the minimum and maximum catalog versions, if they're not set already
-        # in the 'new catalog' if statement above
-        if (
-            yaml_dict["sources"]["access_nri"]["parameters"]["version"].get("min")
-            is None
-        ):
-            yaml_dict = _set_catalog_yaml_version_bounds(
-                yaml_dict,
-                min(version, vmin_old if vmin_old is not None else version),
-                max(version, vmax_old if vmax_old is not None else version),
-            )
+            if (
+                (args_new != args_old or driver_new != driver_old)
+                and vmin_old is not None
+                and vmax_old is not None
+            ):
+                # Move the old catalog out of the way
+                # New catalog.yaml will have restricted version bounds
+                if vmin_old == vmax_old:
+                    vers_str = vmin_old
+                else:
+                    vers_str = f"{vmin_old}-{vmax_old}"
+                Path(cat_loc).rename(Path(cat_loc).parent / f"catalog-{vers_str}.yaml")
+                yaml_dict = _set_catalog_yaml_version_bounds(
+                    yaml_dict, version, version, use_parquet
+                )
+            elif storage_new != storage_old:
+                yaml_dict["sources"][cat_name]["metadata"]["storage"] = (
+                    _combine_storage_flags(storage_new, storage_old)
+                )
+
+            # Set the minimum and maximum catalog versions, if they're not set already
+            # in the 'new catalog' if statement above
+            if (
+                yaml_dict["sources"][cat_name]["parameters"]["version"].get("min")
+                is None
+            ):
+                yaml_dict = _set_catalog_yaml_version_bounds(
+                    yaml_dict,
+                    min(version, vmin_old if vmin_old is not None else version),
+                    max(version, vmax_old if vmax_old is not None else version),
+                    use_parquet,
+                )
 
     if (not existing_cat) or (vmin_old is None and vmax_old is None):
         # No existing catalog, so set min = max = current version,
@@ -385,10 +408,12 @@ def _compute_previous_versions(
                 yaml_dict,
                 min(*existing_vers, version),
                 max(*existing_vers, version),
+                use_parquet,
             )
         else:
-            yaml_dict = _set_catalog_yaml_version_bounds(yaml_dict, version, version)
-
+            yaml_dict = _set_catalog_yaml_version_bounds(
+                yaml_dict, version, version, use_parquet
+            )
     return yaml_dict
 
 
@@ -451,7 +476,7 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
         "--catalog_file",
         type=str,
         default="metacatalog.csv",
-        help="The name of the intake-dataframe-catalog. Defaults to 'metacatalog.csv'",
+        help="The name of the intake-dataframe-catalog. Defaults to 'metacatalog.csv' if `use_parquet` is False, or `metacatalog.parquet` if `use_parquet` is True",
     )
 
     parser.add_argument(
@@ -481,6 +506,13 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
         ),
     )
 
+    parser.add_argument(
+        "--use_parquet",
+        default=False,
+        action="store_true",
+        help=("Set this if you want to use parquet files instead of csv files"),
+    )
+
     args = parser.parse_args(argv)
     config_yamls = args.config_yaml
     build_base_path = args.build_base_path
@@ -490,6 +522,7 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
     version = args.version
     update = not args.no_update
     concretize = not args.no_concretize
+    use_parquet = args.use_parquet
 
     if not version.startswith("v"):
         version = f"v{version}"
@@ -544,7 +577,7 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
         )
 
     # Build the catalog
-    cm = CatalogManager(path=metacatalog_path)
+    cm = CatalogManager(path=metacatalog_path, use_parquet=use_parquet)
     for method, src_args in parsed_sources:
         _add_source_to_catalog(cm, method, src_args, metacatalog_path, logger=logger)
 
@@ -559,7 +592,7 @@ def build(  # noqa: PLR0912, PLR0915 # Allow this func to be long and branching
 
     if update:
         yaml_dict = _compute_previous_versions(
-            yaml_dict, catalog_base_path, build_base_path, version
+            yaml_dict, catalog_base_path, build_base_path, version, use_parquet
         )
     catalog_tmp_path = Path(build_base_path) / f".{version}"
 
@@ -700,9 +733,15 @@ def _concretize_build(  # noqa: PLR0913 # Allow this func to have many arguments
 
     # First, 'unhide' paths in the metacatalog.csv file
     metacatalog_path = Path(build_base_path) / f".{version}" / catalog_file
-    pl.scan_csv(metacatalog_path).with_columns(
-        pl.col("yaml").str.replace(f".{version}", version, literal=True)
-    ).collect().write_csv(metacatalog_path)
+
+    if metacatalog_path.suffix[1:] == "csv":
+        pl.scan_csv(metacatalog_path).with_columns(
+            pl.col("yaml").str.replace(f".{version}", version, literal=True)
+        ).collect().write_csv(metacatalog_path)
+    else:
+        pl.scan_parquet(metacatalog_path).with_columns(
+            pl.col("yaml").str.replace(f".{version}", version, literal=True)
+        ).collect().write_parquet(metacatalog_path)
 
     source_files = (Path(build_base_path) / f".{version}" / "source").glob("*.json")
 
@@ -736,12 +775,16 @@ def _concretize_build(  # noqa: PLR0913 # Allow this func to have many arguments
         catalog_src.rename(catalog_dst)
 
 
-def _set_catalog_yaml_version_bounds(d: dict, bl: str, bu: str) -> dict:
+def _set_catalog_yaml_version_bounds(
+    d: dict, bl: str, bu: str, use_parquet: bool = False
+) -> dict:
     """
     Set the version boundaries for the access_nri_intake_catalog.
     """
-    d["sources"]["access_nri"]["parameters"]["version"]["min"] = bl
-    d["sources"]["access_nri"]["parameters"]["version"]["max"] = bu
+    cat_name: T_catname = "access_nri" if not use_parquet else "access_nri_pq"
+
+    d["sources"][cat_name]["parameters"]["version"]["min"] = bl
+    d["sources"][cat_name]["parameters"]["version"]["max"] = bu
 
     return d
 

--- a/src/access_nri_intake/data/__init__.py
+++ b/src/access_nri_intake/data/__init__.py
@@ -30,9 +30,9 @@ CATALOG_NAME_FORMAT = r"^\.?v(?P<yr>2[0-9]{3})\-(?P<mon>1[0-2]|0[1-9])\-(?P<day>
 
 
 """
-Try/except here attempts to access `access_nri_pq`. Previous versions used the 
+Try/except here attempts to access `access_nri_pq`. Previous versions used the
 `access_nri` attribute. This is set up so that previous versions of the software
-will hit `sources::access_nri` in the yaml, but that this version (and future) 
+will hit `sources::access_nri` in the yaml, but that this version (and future)
 will hit `sources::access_nri_pq`. This allows us to maintain seamless backward
 compatibility while transitioning to the new Parquet-based catalog.
 

--- a/src/access_nri_intake/data/__init__.py
+++ b/src/access_nri_intake/data/__init__.py
@@ -29,8 +29,17 @@ ProductionToggle().production = True
 CATALOG_NAME_FORMAT = r"^\.?v(?P<yr>2[0-9]{3})\-(?P<mon>1[0-2]|0[1-9])\-(?P<day>0[1-9]|[1-2][0-9]|3[0-1])$"
 
 
+"""
+Try/except here attempts to access `access_nri_pq`. Previous versions used the 
+`access_nri` attribute. This is set up so that previous versions of the software
+will hit `sources::access_nri` in the yaml, but that this version (and future) 
+will hit `sources::access_nri_pq`. This allows us to maintain seamless backward
+compatibility while transitioning to the new Parquet-based catalog.
+
+Note: Does not need to be configurable in the code - handled by versioning.
+"""
 try:
-    data = intake.open_catalog(get_catalog_fp()).access_nri
+    data = intake.open_catalog(get_catalog_fp()).access_nri_pq
     cat_version = data._captured_init_kwargs.get("metadata", {}).get(
         "version", "latest"
     )  # Get the catalog version number and set it to "latest" if it can't be found

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2031,27 +2031,34 @@ def test_build_repeat_first_parquet(test_data, tmp_path, fake_project_access):
         cat_yaml_new = yaml.safe_load(fobj)
 
     assert (
-        cat_yaml_new["sources"]["access_nri"]["parameters"]["version_pq"].get("min")
+        cat_yaml_old["sources"]["access_nri"] == cat_yaml_new["sources"]["access_nri"]
+    ), "Catalog source 'access_nri' has changed unexpectedly between builds"
+
+    assert (
+        cat_yaml_new["sources"]["access_nri"]["parameters"]["version"].get("min")
         == "v2024-01-01"
-    ), f"Min version {cat_yaml_new['sources']['access_nri']['parameters']['version_pq'].get('min')} does not match expected v2024-01-01"
+    ), f"Min version {cat_yaml_new['sources']['access_nri']['parameters']['version'].get('min')} does not match expected v2024-01-01"
     assert (
-        cat_yaml_new["sources"]["access_nri"]["parameters"]["version_pq"].get("max")
-        == "v2024-01-02"
-    ), f"Max version {cat_yaml_new['sources']['access_nri']['parameters']['version_pq'].get('max')} does not match expected v2024-01-02"
+        cat_yaml_new["sources"]["access_nri"]["parameters"]["version"].get("max")
+        == "v2024-01-01"
+    ), f"Max version {cat_yaml_new['sources']['access_nri']['parameters']['version'].get('max')} does not match expected v2024-01-02"
     assert (
-        cat_yaml_new["sources"]["access_nri"]["parameters"]["version_pq"].get("default")
+        cat_yaml_new["sources"]["access_nri"]["parameters"]["version"].get("default")
+        == "v2024-01-01"
+    ), f"Default version {cat_yaml_new['sources']['access_nri']['parameters']['version'].get('default')} does not match expected v2024-01-02"
+
+    assert (
+        cat_yaml_new["sources"]["access_nri_pq"]["parameters"]["version"].get("min")
         == "v2024-01-02"
-    ), f"Default version {cat_yaml_new['sources']['access_nri']['parameters']['version_pq'].get('default')} does not match expected v2024-01-02"
-
-    _common_new = cat_yaml_new
-    _common_old = cat_yaml_old
-    _common_new["sources"]["access_nri"]["args"].pop("path")
-    _common_old["sources"]["access_nri"]["args"].pop("path")
-    params_pq = _common_new["sources"]["access_nri"].pop("parameters")
-    params_csv = _common_old["sources"]["access_nri"].pop("parameters")
-
-    assert _common_new == _common_old
-    assert params_pq.get("version", None) == params_csv.get("version")
+    ), f"Min version {cat_yaml_new['sources']['access_nri_pq']['parameters']['version'].get('min')} does not match expected v2024-01-01"
+    assert (
+        cat_yaml_new["sources"]["access_nri_pq"]["parameters"]["version"].get("max")
+        == "v2024-01-02"
+    ), f"Max version {cat_yaml_new['sources']['access_nri_pq']['parameters']['version'].get('max')} does not match expected v2024-01-02"
+    assert (
+        cat_yaml_new["sources"]["access_nri_pq"]["parameters"]["version"].get("default")
+        == "v2024-01-02"
+    ), f"Default version {cat_yaml_new['sources']['access_nri_pq']['parameters']['version'].get('default')} does not match expected v2024-01-02"
 
 
 @pytest.mark.filterwarnings("ignore:Unable to determine project for base path")
@@ -2088,7 +2095,6 @@ def test_build_repeat_csv_after_parquet(test_data, tmp_path, fake_project_access
     # see just a version number change in the yaml
     with (tmp_path / "catalog.yaml").open(mode="r") as fobj:
         cat_yaml_old = yaml.safe_load(fobj)
-    frozen_old = frozendict(copy.deepcopy(cat_yaml_old))
 
     # Update the version number and have another crack at building
     NEW_VERSION = "v2024-01-02"
@@ -2113,39 +2119,28 @@ def test_build_repeat_csv_after_parquet(test_data, tmp_path, fake_project_access
     # see just a version number change in the yaml
     with (tmp_path / "catalog.yaml").open(mode="r") as fobj:
         cat_yaml_new = yaml.safe_load(fobj)
-    frozen_new = frozendict(copy.deepcopy(cat_yaml_new))
 
     assert (
-        cat_yaml_new["sources"]["access_nri"]["parameters"]["version_pq"].get("min")
-        == "v2024-01-01"
-    ), f"Min version {cat_yaml_new['sources']['access_nri']['parameters']['version_pq'].get('min')} does not match expected v2024-01-01"
-    assert (
-        cat_yaml_new["sources"]["access_nri"]["parameters"]["version_pq"].get("max")
+        cat_yaml_new["sources"]["access_nri_pq"]["parameters"]["version"].get("min")
         == "v2024-01-02"
-    ), f"Max version {cat_yaml_new['sources']['access_nri']['parameters']['version_pq'].get('max')} does not match expected v2024-01-02"
+    ), f"Min version {cat_yaml_new['sources']['access_nri_pq']['parameters']['version'].get('min')} does not match expected v2024-01-01"
     assert (
-        cat_yaml_new["sources"]["access_nri"]["parameters"]["version_pq"].get("default")
+        cat_yaml_new["sources"]["access_nri_pq"]["parameters"]["version"].get("max")
         == "v2024-01-02"
-    ), f"Default version {cat_yaml_new['sources']['access_nri']['parameters']['version_pq'].get('default')} does not match expected v2024-01-02"
-
-    # This section mutates the cat_yamls - hence the frozendicts
-    cat_yaml_new["sources"]["access_nri"]["args"].pop("path")
-    cat_yaml_old["sources"]["access_nri"]["args"].pop("path")
-    params_pq = cat_yaml_new["sources"]["access_nri"].pop("parameters")
-    params_csv = cat_yaml_old["sources"]["access_nri"].pop("parameters")
-
-    assert cat_yaml_new == cat_yaml_old
-    assert params_pq.get("version", None) == params_csv.get("version")
+    ), f"Max version {cat_yaml_new['sources']['access_nri_pq']['parameters']['version'].get('max')} does not match expected v2024-01-02"
+    assert (
+        cat_yaml_new["sources"]["access_nri_pq"]["parameters"]["version"].get("default")
+        == "v2024-01-02"
+    ), f"Default version {cat_yaml_new['sources']['access_nri_pq']['parameters']['version'].get('default')} does not match expected v2024-01-02"
 
     # Now we build a new csv catalog. We're expecting to see changes to the `version` but not `version_pq`
-
     # Update the version number and have another crack at building, this time csv again
     NEWEST_VERSION = "v2025-01-02"
     build(
         [
             *configs,
             "--catalog_file",
-            "cat.parquet",
+            "cat.csv",
             "--data_base_path",
             data_base_path,
             "--build_base_path",
@@ -2162,24 +2157,16 @@ def test_build_repeat_csv_after_parquet(test_data, tmp_path, fake_project_access
     # see just a version number change in the yaml
     with (tmp_path / "catalog.yaml").open(mode="r") as fobj:
         cat_yaml_newest = yaml.safe_load(fobj)
-        frozen_newest = frozendict(copy.deepcopy(cat_yaml_newest))
 
     assert (
         cat_yaml_newest["sources"]["access_nri"]["parameters"]["version"].get("min")
         == "v2024-01-01"
-    ), f"Min version {cat_yaml_newest['sources']['access_nri']['parameters']['version_pq'].get('min')} does not match expected v2024-01-01"
+    ), f"Min version {cat_yaml_newest['sources']['access_nri']['parameters']['version'].get('min')} does not match expected v2024-01-01"
     assert (
         cat_yaml_newest["sources"]["access_nri"]["parameters"]["version"].get("max")
         == "v2025-01-02"
-    ), f"Max version {cat_yaml_newest['sources']['access_nri']['parameters']['version_pq'].get('max')} does not match expected v2024-01-02"
+    ), f"Max version {cat_yaml_newest['sources']['access_nri']['parameters']['version'].get('max')} does not match expected v2024-01-02"
     assert (
         cat_yaml_newest["sources"]["access_nri"]["parameters"]["version"].get("default")
         == "v2025-01-02"
-    ), f"Default version {cat_yaml_newest['sources']['access_nri']['parameters']['version_pq'].get('default')} does not match expected v2024-01-02"
-
-    cat_yaml_newest["sources"]["access_nri"]["args"].pop("path")
-    params_csv_newest = cat_yaml_newest["sources"]["access_nri"].pop("parameters")
-
-    assert cat_yaml_newest == cat_yaml_old
-
-    assert params_csv_newest["version_pq"] == params_pq["version_pq"]
+    ), f"Default version {cat_yaml_newest['sources']['access_nri']['parameters']['version'].get('default')} does not match expected v2024-01-02"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2171,6 +2171,7 @@ def test_build_repeat_csv_after_parquet(test_data, tmp_path, fake_project_access
         == "v2025-01-02"
     ), f"Default version {cat_yaml_newest['sources']['access_nri']['parameters']['version'].get('default')} does not match expected v2024-01-02"
 
+
 @pytest.mark.parametrize(
     "version",
     [

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -8,6 +8,7 @@ from warnings import warn
 import pytest
 from intake_dataframe_catalog.core import DfFileCatalogError
 from pandas.errors import EmptyDataError
+from pathlib import Path
 
 from access_nri_intake.catalog import EXP_JSONSCHEMA
 from access_nri_intake.catalog.manager import CatalogManager, CatalogManagerError
@@ -37,6 +38,21 @@ def test_CatalogManager_init(tmp_path):
     assert "first load or build the source" in str(excinfo.value)
 
 
+def test_CatalogManager_init_parquet(tmp_path):
+    """Test that CatalogManager initialising correctly"""
+    path = str(tmp_path / "cat.parquet")
+
+    cat = CatalogManager(path)
+    assert cat.mode == "w"
+    assert hasattr(cat, "dfcat")
+
+    assert cat.dfcat.format == "parquet"
+
+    with pytest.raises(CatalogManagerError) as excinfo:
+        cat._add()
+    assert "first load or build the source" in str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     "builder, basedir, kwargs",
     [
@@ -46,11 +62,14 @@ def test_CatalogManager_init(tmp_path):
         (AccessOm3Builder, "access-om3", {}),
     ],
 )
+@pytest.mark.parametrize("use_parquet", [True, False])
 @pytest.mark.filterwarnings("ignore:Unable to parse 2 assets")
-def test_CatalogManager_build_esm(tmp_path, test_data, builder, basedir, kwargs):
+def test_CatalogManager_build_esm(
+    tmp_path, test_data, builder, basedir, kwargs, use_parquet
+):
     """Test building and adding an Intake-ESM datastore"""
     path = str(tmp_path / "cat.csv")
-    cat = CatalogManager(path)
+    cat = CatalogManager(path, use_parquet)
 
     metadata = load_metadata_yaml(
         str(test_data / basedir / "metadata.yaml"), EXP_JSONSCHEMA
@@ -77,6 +96,9 @@ def test_CatalogManager_build_esm(tmp_path, test_data, builder, basedir, kwargs)
     cat.save()
     cat = CatalogManager(path)
     assert cat.mode == "a"
+    # Confirm we wrote out parquet, not csv, files
+    assert (Path(cat.path).parent / "test.csv").exists() != use_parquet
+    assert (Path(cat.path).parent / "test.parquet").exists() == use_parquet
 
 
 @mock.patch("intake_dataframe_catalog.core.DfFileCatalog.__init__")


### PR DESCRIPTION
## Change Summary

- `CatalogManager` class can be configured with the `use_parquet` flag to serialise the catalog as parquet.

## Related issue number

- [x] #518 
- [x] #535 
- [x] #540
- [ ] #539 || I'd like to hit this in this PR, but I think it's unfeasibly large to include the changes in here.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable N/A

___

Closes #540 

N.B This will also introduce a pile of bugs in the `data.utils` module surrounding versioning information available to users. TBH I don't confident addressing those in this PR: the version logic has gotten so out of hand with this (notes in the code comments) that we need to do some major refactoring before any of that can be addressed IMO.