### PR TITLE
Fix `gadi-deploy`

### DIFF
--- a/.github/workflows/gadi_deploy.yml
+++ b/.github/workflows/gadi_deploy.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Checkout code, setup pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e
+        with: 
+          environments: default
+          frozen: true # This seems hacky?
 
       - name: Mirror the catalog from Gadi to Nectar
         env: 


### PR DESCRIPTION
Turns out we need to specify env, can't just use default