### PR TITLE
603: Fix string iteration in aliasing

### DIFF
--- a/src/access_nri_intake/aliases.py
+++ b/src/access_nri_intake/aliases.py
@@ -159,11 +159,9 @@ class AliasedESMCatalog:
 
         # list/tuple/set of strings
         if isinstance(value, (list | tuple | set)):
-            out = set()
-            for v in value:
-                normalized = aliases_for_field.get(v, v)
-                out.add(v)
-                [out.add(n) for n in normalized]  # type: ignore[func-returns-value]
+            out = _normalize_list_vals(
+                value, aliases_for_field, field, self.show_warnings
+            )
 
             # If any aliasing occurred, issue a warning showing the original and aliased values
             if len(out) > len(value) and self.show_warnings:
@@ -286,17 +284,9 @@ class AliasedDataframeCatalog:
 
         # list/tuple/set of strings
         if isinstance(value, (list | tuple | set)):
-            out = set()
-            for v in value:
-                normalized = aliases_for_field.get(v, v)
-                if normalized != v and self.show_warnings:
-                    warnings.warn(
-                        message=f"Value aliasing: {field}='{v}' → {field}=['{','.join(n for n in normalized)}','{v}']",
-                        category=UserWarning,
-                        stacklevel=4,
-                    )
-                out.add(v)
-                [out.add(n) for n in normalized]  # type: ignore[func-returns-value]
+            out = _normalize_list_vals(
+                value, aliases_for_field, field, self.show_warnings
+            )
             return type(value)(out)
 
         # anything else (regex, callable, etc.) – leave untouched
@@ -358,6 +348,27 @@ class AliasedDataframeCatalog:
         return sorted(
             set(dir(self._cat)) | set(self.__dict__.keys())
         )  # pragma: no cover
+
+
+def _normalize_list_vals(
+    value, aliases_for_field: dict[str, Any], field: str, show_warnings: bool
+) -> set[str]:
+    out = set()
+    for v in value:
+        normalized = aliases_for_field.get(v, None)
+        if normalized is None:
+            out.add(v)
+            continue
+
+        if normalized != v and show_warnings:
+            warnings.warn(
+                message=f"Value aliasing: {field}='{v}' → {field}=['{','.join(n for n in normalized)}','{v}']",
+                category=UserWarning,
+                stacklevel=4,
+            )
+        out.add(v)
+        [out.add(n) for n in normalized]  # type: ignore[func-returns-value]
+    return out
 
 
 # Load CMIP to ACCESS variable mappings

--- a/src/access_nri_intake/aliases.py
+++ b/src/access_nri_intake/aliases.py
@@ -355,10 +355,7 @@ def _normalize_list_vals(
 ) -> set[str]:
     out = set()
     for v in value:
-        normalized = aliases_for_field.get(v, None)
-        if normalized is None:
-            out.add(v)
-            continue
+        normalized = aliases_for_field.get(v, [v])
 
         if normalized != v and show_warnings:
             warnings.warn(

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -204,7 +204,7 @@ class TestAliasedESMCatalog:
             # list nonsense
             with pytest.warns(UserWarning) as warning_record:
                 wrapped_cat.search(variable=["ci", "cl", "tas"])
-            assert len(warning_record) == 1
+            assert len(warning_record) == 4
         else:
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
@@ -346,6 +346,29 @@ class TestAliasedESMCatalog:
 
         unwrapped = wrapped_cat.unwrap()
         assert unwrapped is sample_datastore_path
+
+    def test_no_fallback_string_iteration(self, sample_datastore_path):
+        """Test that string values are not iterated over if aliaed_for field turfs up
+        nothing"""
+
+        sample_datastore_path = esm_datastore(
+            sample_datastore_path, columns_with_iterables=["variable"]
+        )
+        wrapped_cat = AliasedESMCatalog(
+            sample_datastore_path,
+            field_aliases=ESM_FIELD_ALIASES,
+            value_aliases=VALUE_ALIASES,
+        )
+
+        inp_search = {"variable": ["field_without_aliases"]}
+
+        ret = wrapped_cat._normalise_kwargs(
+            inp_search
+        )  # Should not raise an error or iterate over string characters
+
+        assert (
+            ret == inp_search
+        )  # Should have passed through the original value in a list
 
 
 @pytest.mark.filterwarnings("ignore:Value aliasing")
@@ -530,6 +553,26 @@ class TestAliasedDataframeCatalog:
         unwrapped = catalog.unwrap()
 
         assert unwrapped is tmp_dataframe_catalog
+
+    def test_no_fallback_string_iteration(self, tmp_dataframe_catalog):
+        """Test that string values are not iterated over if aliaed_for field turfs up
+        nothing"""
+
+        catalog = AliasedDataframeCatalog(
+            tmp_dataframe_catalog,
+            field_aliases=DATAFRAME_FIELD_ALIASES,
+            value_aliases=VALUE_ALIASES,
+        )
+
+        inp_search = {"variable": ["field_without_aliases"]}
+
+        ret = catalog._normalise_kwargs(
+            inp_search
+        )  # Should not raise an error or iterate over string characters
+
+        assert (
+            ret == inp_search
+        )  # Should have passed through the original value in a list
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

- [x] Test that we don't iterate over strings when they're in a collection via an ill-thought through str fallback. 947b02b
- [x] Add code fixing it. aa27725

## Related issue number

Closes #603 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [N/A] Documentation reflects the changes where applicable
