### PR TITLE
Change snappy to ztd compression

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -148,7 +148,7 @@ class BaseBuilder(Builder):
         if use_parquet:
             kwargs = {
                 "file_format": "parquet",
-                "write_kwargs": {"compression": "snappy"},
+                "write_kwargs": {"compression": "zstd"},
             }
         else:
             kwargs = {


### PR DESCRIPTION
## Change Summary

- Change snappy to zstd compression in the builders.
- Snappy is old & worse (in general...).
- Brings the builders into line with the `cloud.py` compression.

See benchmarks here (plenty of other sources but this one looks just at parquet rather than iceberg layers etc on parquet): 
<img width="800" height="477" alt="image" src="https://github.com/user-attachments/assets/b6dac310-0352-439a-bf94-e7941e312805" />

Slightly slower to decompress but otherwise generally preferred.

https://readmedium.com/zstd-vs-snappy-vs-gzip-the-compression-king-for-parquet-has-arrived-b4937a488b8e

## Related issue number

N/A

## Checklist

- [NA] Unit tests for the changes exist
- [x] Tests pass on CI
