### PR TITLE
Update builders so that kwargs can be manually set

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -27,13 +27,13 @@ __all__ = [
     "AccessOm3Builder",
     "Mom6Builder",
     "AccessEsm15Builder",
-    "AccessEsm16Builder",
     "AccessCm2Builder",
+    "AccessEsm16Builder",
+    "OnlineMltBuilder",
     "AccessCm3Builder",
     "ROMSBuilder",
     "WoaBuilder",
     "Cmip6Builder",
-    "OnlineMltBuilder",
 ]
 
 # Frequency translations
@@ -78,7 +78,7 @@ class BaseBuilder(Builder):
     # child classes.
     PATTERNS: list = ["*.nc"]
 
-    def __init__(  # noqa: PLR0913 # Allow this func to have many agruments
+    def __init__(  # noqa: PLR0913 # Allow this func to have many arguments
         self,
         path: str | list[str],
         depth: int = 0,

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -1,7 +1,13 @@
 # Copyright 2023 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Builders for generating Intake-ESM datastores"""
+"""Builders for generating Intake-ESM datastores
+
+Note: It looks like the {**default_kwargs, **kwargs} pattern is repeated a lot in
+the builders. The default kwargs all look very similar, but *are not the same*.
+Trying to unify them without a bunch of extra effort (probably making the
+deduplication effort wasted/more complex than it currently is) is not going to work.
+"""
 
 import multiprocessing
 import re
@@ -428,11 +434,11 @@ class AccessOm2Builder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=3,
-            exclude_patterns=kwargs.get("exclude_patterns") or ["*restart*", "*o2i.nc"],
-            include_patterns=kwargs.get("include_patterns") or ["*.nc"],
+            exclude_patterns=kwargs.get("exclude_patterns", ["*restart*", "*o2i.nc"]),
+            include_patterns=kwargs.get("include_patterns", ["*.nc"]),
             data_format="netcdf",
             groupby_attrs=[
                 "file_id",
@@ -449,6 +455,7 @@ class AccessOm2Builder(BaseBuilder):
                 },
             ],
         )
+        kwargs = {**default_kwargs, **kwargs}
 
         super().__init__(**kwargs)
 
@@ -492,7 +499,7 @@ class AccessOm3Builder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=2,
             exclude_patterns=kwargs.get(
@@ -521,6 +528,7 @@ class AccessOm3Builder(BaseBuilder):
                 },
             ],
         )
+        kwargs = {**default_kwargs, **kwargs}
 
         super().__init__(**kwargs)
 
@@ -567,7 +575,7 @@ class Mom6Builder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=1,
             exclude_patterns=kwargs.get("exclude_patterns")
@@ -597,6 +605,7 @@ class Mom6Builder(BaseBuilder):
             ],
         )
 
+        kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)
 
     @classmethod
@@ -639,11 +648,11 @@ class AccessEsm15Builder(BaseBuilder):
             along a new member dimension
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=3,
-            exclude_patterns=kwargs.get("exclude_patterns") or ["*restart*"],
-            include_patterns=kwargs.get("include_patterns") or ["*.nc*"],
+            exclude_patterns=kwargs.get("exclude_patterns", ["*restart*"]),
+            include_patterns=kwargs.get("include_patterns", ["*.nc*"]),
             data_format="netcdf",
             groupby_attrs=[
                 "file_id",
@@ -662,13 +671,14 @@ class AccessEsm15Builder(BaseBuilder):
         )
 
         if ensemble:
-            kwargs["aggregations"] += [
+            default_kwargs["aggregations"] += [
                 {
                     "type": "join_new",
                     "attribute_name": "member",
                 },
             ]
 
+        kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)
 
     @classmethod
@@ -781,7 +791,7 @@ class AccessCm3Builder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=2,
             exclude_patterns=kwargs.get("exclude_patterns")
@@ -809,7 +819,7 @@ class AccessCm3Builder(BaseBuilder):
                 },
             ],
         )
-
+        kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)
 
     @classmethod
@@ -861,7 +871,7 @@ class ROMSBuilder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=1,
             exclude_patterns=kwargs.get("exclude_patterns", ["*avg*", "*rst*"]),
@@ -883,6 +893,7 @@ class ROMSBuilder(BaseBuilder):
             ],
         )
 
+        kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)
 
     @classmethod
@@ -919,7 +930,7 @@ class WoaBuilder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=2,
             exclude_patterns=kwargs.get("exclude_patterns", ["*avg*", "*rst*"]),
@@ -941,6 +952,7 @@ class WoaBuilder(BaseBuilder):
             ],
         )
 
+        kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)
 
     @classmethod
@@ -985,7 +997,7 @@ class Cmip6Builder(BaseBuilder):
             Path or list of paths to crawl for assets/files.
         """
 
-        kwargs = dict(
+        default_kwargs = dict(
             path=path,
             depth=1,
             exclude_patterns=kwargs.get("exclude_patterns", ["*avg*", "*rst*"]),
@@ -1008,15 +1020,17 @@ class Cmip6Builder(BaseBuilder):
         )
 
         if ensemble:
-            kwargs["aggregations"] += [
+            default_kwargs["aggregations"] += [
                 {
                     "type": "join_new",
                     "attribute_name": "member",
                 },
             ]
-            kwargs["groupby_attrs"] += ["member"]
+            default_kwargs["groupby_attrs"] += ["member"]
 
         Cmip6Builder.ensemble = ensemble
+
+        kwargs = {**default_kwargs, **kwargs}
 
         super().__init__(**kwargs)
 

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -578,16 +578,18 @@ class Mom6Builder(BaseBuilder):
         default_kwargs = dict(
             path=path,
             depth=1,
-            exclude_patterns=kwargs.get("exclude_patterns")
-            or [
-                "*restart*",
-                "*MOM_IC.nc",
-                "*sea_ice_geometry.nc",
-                "*ocean_geometry.nc",
-                "*ocean.stats.nc",
-                "*Vertical_coordinate.nc",
-            ],
-            include_patterns=kwargs.get("include_patterns") or ["*.nc"],
+            exclude_patterns=kwargs.get(
+                "exclude_patterns",
+                [
+                    "*restart*",
+                    "*MOM_IC.nc",
+                    "*sea_ice_geometry.nc",
+                    "*ocean_geometry.nc",
+                    "*ocean.stats.nc",
+                    "*Vertical_coordinate.nc",
+                ],
+            ),
+            include_patterns=kwargs.get("include_patterns", ["*.nc"]),
             data_format="netcdf",
             groupby_attrs=[
                 "file_id",
@@ -794,15 +796,17 @@ class AccessCm3Builder(BaseBuilder):
         default_kwargs = dict(
             path=path,
             depth=2,
-            exclude_patterns=kwargs.get("exclude_patterns")
-            or [
-                "*restart*",
-                "*MOM_IC.nc",
-                "*ocean_geometry.nc",
-                "*ocean.stats.nc",
-                "*Vertical_coordinate.nc",
-            ],
-            include_patterns=kwargs.get("include_patterns") or ["*.nc"],
+            exclude_patterns=kwargs.get(
+                "exclude_patterns",
+                [
+                    "*restart*",
+                    "*MOM_IC.nc",
+                    "*ocean_geometry.nc",
+                    "*ocean.stats.nc",
+                    "*Vertical_coordinate.nc",
+                ],
+            ),
+            include_patterns=kwargs.get("include_patterns", ["*.nc"]),
             data_format="netcdf",
             groupby_attrs=[
                 "file_id",

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3345,3 +3345,29 @@ def test_builder_year_before_1000(
     asset = builder.parser(path)
 
     assert asset["start_date"] == expected_startdate_str
+
+
+@pytest.mark.parametrize(
+        "builder",
+        [
+            builders.AccessOm2Builder,
+            builders.AccessOm3Builder,
+            builders.Mom6Builder,
+            builders.AccessEsm15Builder,
+            builders.AccessCm2Builder,
+            builders.AccessEsm16Builder,
+            builders.OnlineMltBuilder,
+            builders.AccessCm3Builder,
+            builders.ROMSBuilder,
+            builders.WoaBuilder,
+            builders.Cmip6Builder,
+        ]
+)
+def test_builder_uses_parsed_kwargs(builder: builders.BaseBuilder):
+    """
+    Ensure that if we pass **kwargs into a builder, it is not overwritten by the
+    default kwargs dict. It should probably be extended, not dropped, by default
+    """
+
+
+

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3363,28 +3363,30 @@ def test_builder_year_before_1000(
         (builders.Cmip6Builder, [False]),
     ],
 )
-@mock.patch("access_nri_intake.source.builders.BaseBuilder.__init__", autospec=True, return_value=None)
-def test_builder_uses_parsed_kwargs(mock_base_init, builder: builders.BaseBuilder, args):
+@mock.patch(
+    "access_nri_intake.source.builders.BaseBuilder.__init__",
+    autospec=True,
+    return_value=None,
+)
+def test_builder_uses_parsed_kwargs(
+    mock_base_init, builder: builders.BaseBuilder, args
+):
     """
     Ensure that if we pass **kwargs into a builder, it is not overwritten by the
     default kwargs dict. It should probably be extended, not dropped, by default
 
     Autospec is set to false because the BaseBuilder.__init__ specifies which args
-    it can take. Since it just passed 
+    it can take. Since it just passed
     """
 
-    user_kwargs = {"storage_options" : "stupid_test_value"}
-    builder(str("fake_path"),*args, **user_kwargs)
+    user_kwargs = {"storage_options": "stupid_test_value"}
+    builder(str("fake_path"), *args, **user_kwargs)
     mock_base_init.assert_called_once()
     passed_kwargs = mock_base_init.call_args.kwargs
     assert "storage_options" in passed_kwargs
     assert passed_kwargs["storage_options"] == "stupid_test_value"
 
-    
-    user_kwargs = {"not_accepted_kwarg" : "stupid_test_value"}
+    user_kwargs = {"not_accepted_kwarg": "stupid_test_value"}
     with pytest.raises(TypeError):
         # BaseBuilder.__init__ should raise a TypeError here since it won't accept this.
-        builder(str("fake_path"),*args, **user_kwargs)
-
-    
-
+        builder(str("fake_path"), *args, **user_kwargs)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3368,6 +3368,6 @@ def test_builder_uses_parsed_kwargs(builder: builders.BaseBuilder):
     Ensure that if we pass **kwargs into a builder, it is not overwritten by the
     default kwargs dict. It should probably be extended, not dropped, by default
     """
-
+    assert True
 
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3348,24 +3348,43 @@ def test_builder_year_before_1000(
 
 
 @pytest.mark.parametrize(
-    "builder",
+    "builder, args",
     [
-        builders.AccessOm2Builder,
-        builders.AccessOm3Builder,
-        builders.Mom6Builder,
-        builders.AccessEsm15Builder,
-        builders.AccessCm2Builder,
-        builders.AccessEsm16Builder,
-        builders.OnlineMltBuilder,
-        builders.AccessCm3Builder,
-        builders.ROMSBuilder,
-        builders.WoaBuilder,
-        builders.Cmip6Builder,
+        (builders.AccessOm2Builder, []),
+        (builders.AccessOm3Builder, []),
+        (builders.Mom6Builder, []),
+        (builders.AccessEsm15Builder, [False]),
+        (builders.AccessCm2Builder, [False]),
+        (builders.AccessEsm16Builder, [False]),
+        (builders.OnlineMltBuilder, [False]),
+        (builders.AccessCm3Builder, []),
+        (builders.ROMSBuilder, []),
+        (builders.WoaBuilder, []),
+        (builders.Cmip6Builder, [False]),
     ],
 )
-def test_builder_uses_parsed_kwargs(builder: builders.BaseBuilder):
+@mock.patch("access_nri_intake.source.builders.BaseBuilder.__init__", autospec=True, return_value=None)
+def test_builder_uses_parsed_kwargs(mock_base_init, builder: builders.BaseBuilder, args):
     """
     Ensure that if we pass **kwargs into a builder, it is not overwritten by the
     default kwargs dict. It should probably be extended, not dropped, by default
+
+    Autospec is set to false because the BaseBuilder.__init__ specifies which args
+    it can take. Since it just passed 
     """
-    assert True
+
+    user_kwargs = {"storage_options" : "stupid_test_value"}
+    builder(str("fake_path"),*args, **user_kwargs)
+    mock_base_init.assert_called_once()
+    passed_kwargs = mock_base_init.call_args.kwargs
+    assert "storage_options" in passed_kwargs
+    assert passed_kwargs["storage_options"] == "stupid_test_value"
+
+    
+    user_kwargs = {"not_accepted_kwarg" : "stupid_test_value"}
+    with pytest.raises(TypeError):
+        # BaseBuilder.__init__ should raise a TypeError here since it won't accept this.
+        builder(str("fake_path"),*args, **user_kwargs)
+
+    
+

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3348,20 +3348,20 @@ def test_builder_year_before_1000(
 
 
 @pytest.mark.parametrize(
-        "builder",
-        [
-            builders.AccessOm2Builder,
-            builders.AccessOm3Builder,
-            builders.Mom6Builder,
-            builders.AccessEsm15Builder,
-            builders.AccessCm2Builder,
-            builders.AccessEsm16Builder,
-            builders.OnlineMltBuilder,
-            builders.AccessCm3Builder,
-            builders.ROMSBuilder,
-            builders.WoaBuilder,
-            builders.Cmip6Builder,
-        ]
+    "builder",
+    [
+        builders.AccessOm2Builder,
+        builders.AccessOm3Builder,
+        builders.Mom6Builder,
+        builders.AccessEsm15Builder,
+        builders.AccessCm2Builder,
+        builders.AccessEsm16Builder,
+        builders.OnlineMltBuilder,
+        builders.AccessCm3Builder,
+        builders.ROMSBuilder,
+        builders.WoaBuilder,
+        builders.Cmip6Builder,
+    ],
 )
 def test_builder_uses_parsed_kwargs(builder: builders.BaseBuilder):
     """
@@ -3369,5 +3369,3 @@ def test_builder_uses_parsed_kwargs(builder: builders.BaseBuilder):
     default kwargs dict. It should probably be extended, not dropped, by default
     """
     assert True
-
-


### PR DESCRIPTION
## Change Summary

- Previously, we were overwriting kwargs so that users couldn't actually set them...
- This addresses that. 

## Related issue number
 
Closes #611 

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
