### PR TITLE
ci: Update conda build to use the access-nri action (fixed conda-build issues)

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - pip
     - versioneer
     - setuptools >=61.0.0
-    - conda-build
   run:
     - python >=3.10
     {% for dep in deps %}

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
     - versioneer
     - setuptools >=61.0.0
+    - conda-build
   run:
     - python >=3.10
     {% for dep in deps %}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,24 +50,9 @@ jobs:
           auto-update-conda: false
           auto-activate-base: false
           show-channel-urls: true
-          
-      - name: Enforce .tar.bz2 packages
-        # Temporary work-arounds while the action uibcdf/action-build-and-upload-conda-packages gets updated:
-        # We create a `~/.condarc` file with the correct options to enforce the use of `.tar.bz2` packages
-        # and we set the channels to be used by conda build
-        shell: bash
-        run: |
-            cat > ~/.condarc << EOF
-            conda-build:
-                pkg_format: .tar.bz2
-            channels:
-                - accessnri
-                - conda-forge
-                - nodefaults
-            EOF
 
       - name: Build and upload the conda package
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.5.0
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.0.0
         with:
           meta_yaml_dir: .conda
           python-version: 3.11

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
           show-channel-urls: true
 
       - name: Build and upload the conda package
-        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.0.0
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.1.0
         with:
           meta_yaml_dir: .conda
           python-version: 3.11


### PR DESCRIPTION
~~Add to the build environment - looks like it's been split out.~~

~~See also https://github.com/ACCESS-NRI/access-nri-intake-catalog/actions/runs/25716623291/job/75507991152~~

See https://github.com/ACCESS-NRI/action-build-and-upload-conda-packages/issues/9