### PR TITLE
Added exclusion pattern to woa23 config

### DIFF
--- a/config/woa.yaml
+++ b/config/woa.yaml
@@ -11,3 +11,8 @@ sources:
   - metadata_yaml: /g/data/xp65/admin/intake/metadata/woa23_av17/metadata.yaml
     path:
     - /g/data/av17/access-nri/OM3/woa23
+    exclude_patterns:
+    # The raw annual files have incorrect time values
+    # - the raw/uncorrected files are under annual_files/raw
+    # - the files with corrected time values under annual_files/corrected_times
+    - "*annual_files/raw/*.nc"


### PR DESCRIPTION
## Change Summary

Excludes uncorrected annual files from WOA23 build

## Related issue number

Closes #618 

## Checklist

- [x] Unit tests for the changes exist
  - Config only change, exclusion patterns already tested
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
  - N/A

<!-- Delete this section unless you have added a new translator/datastore: -->
- [x] You have generated a valid `metadata.yaml` for the datastore & placed it in the correct location: eg. `config/metadata_sources/esgf-ref-qv56/metadata.yaml` for the `esgf-ref-qv56` datastore.
    - File already exists at `config/woa.yaml`
- [x] The `metadata.yaml` has been copied to the correct location in `/g/data/xp65/admin/intake`
    - `metadata.yaml` unchanged

## Notes

- In order to build a new catalog including this additional datastore, you will need to either release a new version of the `access-nri-intake` package, or run the `bin/build_all.sh` script to build a new catalog, using a virtual environment with the most recent (ie. including this PR) version of `access-nri-intake` installed. This can be done by activating the `venv` in `/g/data/xp65/admin/access-nri-intake-catalog/bin/build_all.sh` job.
<!-- End of Translator Change section  -->

<!--
Please add any other relevant info below:
-->