### PR TITLE
Fix aliased catalog dunder methods

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -9605,6 +9605,7 @@ packages:
   - colorama
   - yamanifest>=0.3.12
   - access-py-telemetry>=0.1.6
+  - wrapt>=2.1.2
   - pytest ; extra == 'test'
   - tox ; extra == 'test'
   - pytest ; extra == 'e2e'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "colorama",
     "yamanifest>=0.3.12",
     "access-py-telemetry>=0.1.6",
+    "wrapt>=2.1.2",
 ]
 
 [project.optional-dependencies]
@@ -210,5 +211,3 @@ python = "3.13.*"
 [tool.pixi.feature.py314.dependencies]
 python = "3.14.*"
 
-[tool.pixi.dependencies]
-wrapt = ">=2.1.2,<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,3 +209,6 @@ python = "3.13.*"
 
 [tool.pixi.feature.py314.dependencies]
 python = "3.14.*"
+
+[tool.pixi.dependencies]
+wrapt = ">=2.1.2,<3"

--- a/src/access_nri_intake/aliases.py
+++ b/src/access_nri_intake/aliases.py
@@ -41,6 +41,7 @@ from importlib import resources as rsr
 from typing import Any, TypeVar
 
 import pydantic
+import wrapt
 from intake_dataframe_catalog.core import DfFileCatalog
 from intake_esm.core import esm_datastore
 
@@ -85,7 +86,7 @@ def _load_cmip_mappings() -> dict[str, tuple[str]]:
         return {}
 
 
-class AliasedESMCatalog:
+class AliasedESMCatalog(wrapt.ObjectProxy):
     """
     Thin wrapper around an intake-esm ESMDataStore that:
       - maps public field names → canonical fields (FIELD_ALIASES)
@@ -111,7 +112,7 @@ class AliasedESMCatalog:
         value_aliases: dict[str, Any] | None = None,
         show_warnings: bool = True,
     ):
-        self._cat = cat
+        super().__init__(cat)
         self.field_aliases = field_aliases or {}
         self.value_aliases = value_aliases or {}
         self.show_warnings = show_warnings
@@ -190,25 +191,25 @@ class AliasedESMCatalog:
     def search(self, **kwargs) -> esm_datastore:
         """Search the catalog with aliased field names and values"""
         norm: dict[str, Any] = self._normalise_kwargs(kwargs)
-        return self._cat.search(**norm)
+        return self.__wrapped__.search(**norm)
 
     def unwrap(self) -> esm_datastore:
         """
         Get the underlying dataframe catalog without aliasing
         """
-        return self._cat
+        return self.__wrapped__
 
     # pass-through everything else to underlying catalog
     def __getattr__(self, name):
-        return getattr(self._cat, name)
+        return getattr(self.__wrapped__, name)
 
     def __dir__(self) -> list[str]:
         return sorted(
-            set(dir(self._cat)) | set(self.__dict__.keys())
+            set(dir(self.__wrapped__)) | set(self.__dict__.keys())
         )  # pragma: no cover
 
 
-class AliasedDataframeCatalog:
+class AliasedDataframeCatalog(wrapt.ObjectProxy):
     """
     Wrapper around an intake dataframe catalog that provides alias support
     for catalog entries that are ESM datastores.
@@ -232,7 +233,7 @@ class AliasedDataframeCatalog:
         value_aliases: dict[str, Any] | None = None,
         show_warnings: bool = True,
     ):
-        self._cat = cat
+        super().__init__(cat)
         self.field_aliases = field_aliases or {}
         self.value_aliases = value_aliases or {}
         self.show_warnings = show_warnings
@@ -257,7 +258,7 @@ class AliasedDataframeCatalog:
         """
         Handle catalog['entry-name'] access - delegate to underlying catalog
         """
-        result = self._cat[key]
+        result = self.__wrapped__[key]
         return self._wrap_if_esm_datastore(result)
 
     def _normalise_value(self, field: str, value: str | Collection[str] | Any) -> Any:
@@ -307,7 +308,7 @@ class AliasedDataframeCatalog:
         # We don't need to alias these searches since they're on the catalog structure
 
         norm: dict[str, Any] = self._normalise_kwargs(kwargs)
-        result: DfFileCatalog = self._cat.search(**norm)
+        result: DfFileCatalog = self.__wrapped__.search(**norm)
 
         return AliasedDataframeCatalog(
             result,
@@ -320,14 +321,14 @@ class AliasedDataframeCatalog:
         """
         Get ESM datastore from catalog search result - wrap with aliasing
         """
-        result = self._cat.to_source(**kwargs)
+        result = self.__wrapped__.to_source(**kwargs)
         return self._wrap_if_esm_datastore(result)
 
     def to_source_dict(self, **kwargs):
         """
         Get dict of ESM datastores from catalog search result - wrap each with aliasing
         """
-        result = self._cat.to_source_dict(**kwargs)
+        result = self.__wrapped__.to_source_dict(**kwargs)
         # Wrap each datastore in the dictionary
         wrapped_result = {}
         for key, datastore in result.items():
@@ -338,15 +339,15 @@ class AliasedDataframeCatalog:
         """
         Get the underlying dataframe catalog without aliasing
         """
-        return self._cat
+        return self.__wrapped__
 
     # pass-through everything else to underlying catalog
     def __getattr__(self, name):
-        return getattr(self._cat, name)
+        return getattr(self.__wrapped__, name)
 
     def __dir__(self) -> list[str]:
         return sorted(
-            set(dir(self._cat)) | set(self.__dict__.keys())
+            set(dir(self.__wrapped__)) | set(self.__dict__.keys())
         )  # pragma: no cover
 
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -590,6 +590,19 @@ class TestAliasedDataframeCatalog:
             ret == inp_search
         )  # Should have passed through the original value in a list
 
+    def test_getattr_dunder_passthrough(self, tmp_dataframe_catalog):
+        """__getattr__ will not pass through dunder attributes by default, because
+        python looks them up on the class, not the instance."""
+
+        catalog = AliasedDataframeCatalog(
+            tmp_dataframe_catalog,
+            field_aliases=DATAFRAME_FIELD_ALIASES,
+            value_aliases=VALUE_ALIASES,
+        )
+
+        # List is giong to call __iter__ - so this test asserts dunders are being
+        # passed through to the wrapped catalog, not swallowed by the wrapper
+        assert list(catalog) == list(tmp_dataframe_catalog)
 
 @pytest.mark.parametrize(
     "mock_target,side_effect",

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -387,6 +387,7 @@ class TestAliasedESMCatalog:
         # passed through to the wrapped catalog, not swallowed by the wrapper
         assert list(wrapped_cat) == list(sample_datastore_path)
 
+
 @pytest.mark.filterwarnings("ignore:Value aliasing")
 class TestAliasedDataframeCatalog:
     """Test the AliasedDataframeCatalog wrapper"""
@@ -603,6 +604,7 @@ class TestAliasedDataframeCatalog:
         # List is giong to call __iter__ - so this test asserts dunders are being
         # passed through to the wrapped catalog, not swallowed by the wrapper
         assert list(catalog) == list(tmp_dataframe_catalog)
+
 
 @pytest.mark.parametrize(
     "mock_target,side_effect",

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -370,6 +370,22 @@ class TestAliasedESMCatalog:
             ret == inp_search
         )  # Should have passed through the original value in a list
 
+    def test_getattr_dunder_passthrough(self, sample_datastore_path):
+        """__getattr__ will not pass through dunder attributes by default, because
+        python looks them up on the class, not the instance."""
+
+        sample_datastore_path = esm_datastore(
+            sample_datastore_path, columns_with_iterables=["variable"]
+        )
+        wrapped_cat = AliasedESMCatalog(
+            sample_datastore_path,
+            field_aliases=ESM_FIELD_ALIASES,
+            value_aliases=VALUE_ALIASES,
+        )
+
+        # List is giong to call __iter__ - so this test asserts dunders are being
+        # passed through to the wrapped catalog, not swallowed by the wrapper
+        assert list(wrapped_cat) == list(sample_datastore_path)
 
 @pytest.mark.filterwarnings("ignore:Value aliasing")
 class TestAliasedDataframeCatalog:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -383,7 +383,7 @@ class TestAliasedESMCatalog:
             value_aliases=VALUE_ALIASES,
         )
 
-        # List is giong to call __iter__ - so this test asserts dunders are being
+        # List is going to call __iter__ - so this test asserts dunders are being
         # passed through to the wrapped catalog, not swallowed by the wrapper
         assert list(wrapped_cat) == list(sample_datastore_path)
 
@@ -601,7 +601,7 @@ class TestAliasedDataframeCatalog:
             value_aliases=VALUE_ALIASES,
         )
 
-        # List is giong to call __iter__ - so this test asserts dunders are being
+        # List is going to call __iter__ - so this test asserts dunders are being
         # passed through to the wrapped catalog, not swallowed by the wrapper
         assert list(catalog) == list(tmp_dataframe_catalog)
 


### PR DESCRIPTION
## Change Summary

It turns out that `__getattr__` doesn't forward dunder methods (it actually looks them up directly on the class). The `wrapt` library handles this all pretty neatly. 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

