### PR TITLE
`build_all.sh`: `--use-parquet` on by default

### DIFF
--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -57,8 +57,9 @@ for conf in ${CONFIGS[@]}; do
     fi
 done
 
-if [ -z "$version" ]; then
-    catalog-build --build_base_path=${OUTPUT_BASE_PATH} --catalog_base_path=${OUTPUT_BASE_PATH} ${config_paths[@]}
-else
-    catalog-build --build_base_path=${OUTPUT_BASE_PATH} --catalog_base_path=${OUTPUT_BASE_PATH} --version=${version} ${config_paths[@]}
+cmd="catalog-build --build_base_path=${OUTPUT_BASE_PATH} --catalog_base_path=${OUTPUT_BASE_PATH} ${config_paths[@]} --use_parquet"
+if [ -n "$version" ]; then
+    cmd="$cmd --version=${version}"
 fi
+
+eval "$cmd"


### PR DESCRIPTION
## Change Summary

- `build_all.sh` now has `--use-parquet` in the command string.
- Tweaked handling of command string to avoid duplication

## Related issue number
N/A