### PR TITLE
Warn if we run use-datastore on a login node

### DIFF
--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -25,7 +25,7 @@ from .data import CATALOG_NAME_FORMAT
 from .experiment import use_datastore
 from .experiment.colours import f_info, f_path, f_reset
 from .experiment.main import scaffold_catalog_entry as _scaffold_catalog_entry
-from .experiment.utils import parse_kwarg, validate_args
+from .experiment.utils import parse_kwarg, validate_args, warn_if_login_node
 from .source import builders
 from .utils import _can_be_array, get_catalog_fp, load_metadata_yaml
 
@@ -1061,6 +1061,10 @@ def use_esm_datastore(argv: Sequence[str] | None = None) -> int:
             f" 'esm_datastore for the model output in {f_info}{{--expt-dir}}{f_reset}'"
         ),
         default=None,
+    )
+
+    warn_if_login_node(
+        msg="build-esm-datastore running on a login node: scheduler may kill job"
     )
 
     args = parser.parse_args(argv)

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -8,6 +8,7 @@ import datetime
 import logging
 import re
 import shutil
+import sys
 import traceback
 import warnings
 from collections.abc import Sequence
@@ -23,9 +24,15 @@ from .catalog import EXP_JSONSCHEMA, translators
 from .catalog.manager import CatalogManager
 from .data import CATALOG_NAME_FORMAT
 from .experiment import use_datastore
-from .experiment.colours import f_info, f_path, f_reset
+from .experiment.colours import f_info, f_path, f_reset, f_warn
 from .experiment.core import scaffold_catalog_entry as _scaffold_catalog_entry
-from .experiment.utils import parse_kwarg, validate_args, warn_if_login_node
+from .experiment.utils import (
+    SchedulerKilledError,
+    catch_scheduler_termination,
+    parse_kwarg,
+    validate_args,
+    warn_if_login_node,
+)
 from .source import builders
 from .utils import _can_be_array, get_catalog_fp, load_metadata_yaml
 
@@ -1098,15 +1105,20 @@ def use_esm_datastore(argv: Sequence[str] | None = None) -> int:
 
     validate_args(builder, builder_kwargs)
 
-    use_datastore(
-        experiment_dir,
-        builder,
-        catalog_dir,
-        builder_kwargs=builder_kwargs,
-        datastore_name=datastore_name,
-        description=description,
-        open_ds=False,
-    )
+    try:
+        with catch_scheduler_termination():
+            use_datastore(
+                experiment_dir,
+                builder,
+                catalog_dir,
+                builder_kwargs=builder_kwargs,
+                datastore_name=datastore_name,
+                description=description,
+                open_ds=False,
+            )
+    except SchedulerKilledError as exc:
+        print(f"{f_warn}{exc}{f_reset}", file=sys.stderr)
+        return 1
 
     return 0
 

--- a/src/access_nri_intake/cli.py
+++ b/src/access_nri_intake/cli.py
@@ -25,7 +25,7 @@ from .data import CATALOG_NAME_FORMAT
 from .experiment import use_datastore
 from .experiment.colours import f_info, f_path, f_reset
 from .experiment.core import scaffold_catalog_entry as _scaffold_catalog_entry
-from .experiment.utils import parse_kwarg, validate_args
+from .experiment.utils import parse_kwarg, validate_args, warn_if_login_node
 from .source import builders
 from .utils import _can_be_array, get_catalog_fp, load_metadata_yaml
 
@@ -1061,6 +1061,10 @@ def use_esm_datastore(argv: Sequence[str] | None = None) -> int:
             f" 'esm_datastore for the model output in {f_info}{{--expt-dir}}{f_reset}'"
         ),
         default=None,
+    )
+
+    warn_if_login_node(
+        msg="build-esm-datastore running on a login node: scheduler may kill job"
     )
 
     args = parser.parse_args(argv)

--- a/src/access_nri_intake/experiment/utils.py
+++ b/src/access_nri_intake/experiment/utils.py
@@ -1,6 +1,7 @@
 import ast
 import json
 import re
+import socket
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum
@@ -16,6 +17,12 @@ from .colours import f_info, f_reset, f_success, f_warn
 
 
 class DataStoreWarning(RuntimeWarning):
+    pass
+
+
+class LoginNodeWarning(RuntimeWarning):
+    """Warning that process may be killed when running on a login node"""
+
     pass
 
 
@@ -361,3 +368,16 @@ def validate_args(builder: Builder, builder_kwargs: dict[str, Any]) -> None:
             raise TypeError(
                 f"Builder kwarg {key} must be of type {expected_type}, not {type(val)}."
             )
+
+
+def warn_if_login_node(msg: str | None = None) -> None:
+    """
+    If we are running on a login node, just raise a warning that the process
+    might be killed by the gadi task controls
+    """
+    hostnamestr = socket.gethostname()
+
+    msg = msg or "Running on a login node: task may be killed by scheduler"
+
+    if "login" in hostnamestr:
+        warnings.warn(message=msg, category=LoginNodeWarning, stacklevel=2)

--- a/src/access_nri_intake/experiment/utils.py
+++ b/src/access_nri_intake/experiment/utils.py
@@ -1,4 +1,8 @@
 import ast
+import json
+import re
+import socket
+import warnings
 from dataclasses import dataclass, field
 from inspect import signature
 from pathlib import Path
@@ -13,6 +17,12 @@ from .colours import f_reset, f_success, f_warn
 
 
 class DataStoreWarning(RuntimeWarning):
+    pass
+
+
+class LoginNodeWarning(RuntimeWarning):
+    """Warning that process may be killed when running on a login node"""
+
     pass
 
 
@@ -152,3 +162,16 @@ def validate_args(builder: Builder, builder_kwargs: dict[str, Any]) -> None:
             raise TypeError(
                 f"Builder kwarg {key} must be of type {expected_type}, not {type(val)}."
             )
+
+
+def warn_if_login_node(msg: str | None = None) -> None:
+    """
+    If we are running on a login node, just raise a warning that the process
+    might be killed by the gadi task controls
+    """
+    hostnamestr = socket.gethostname()
+
+    msg = msg or "Running on a login node: task may be killed by scheduler"
+
+    if "login" in hostnamestr:
+        warnings.warn(message=msg, category=LoginNodeWarning, stacklevel=2)

--- a/src/access_nri_intake/experiment/utils.py
+++ b/src/access_nri_intake/experiment/utils.py
@@ -1,11 +1,13 @@
 import ast
-import json
-import re
+import signal
 import socket
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from inspect import signature
 from pathlib import Path
+from types import FrameType
 from typing import Any
 
 import pandas as pd
@@ -22,6 +24,13 @@ class DataStoreWarning(RuntimeWarning):
 
 class LoginNodeWarning(RuntimeWarning):
     """Warning that process may be killed when running on a login node"""
+
+    pass
+
+
+class SchedulerKilledError(RuntimeError):
+    """Raised when the process receives a SIGTERM, most likely because the job
+    scheduler killed the task (e.g. for exceeding login node resource limits)."""
 
     pass
 
@@ -175,3 +184,30 @@ def warn_if_login_node(msg: str | None = None) -> None:
 
     if "login" in hostnamestr:
         warnings.warn(message=msg, category=LoginNodeWarning, stacklevel=2)
+
+
+@contextmanager
+def catch_scheduler_termination(msg: str | None = None) -> Iterator[None]:
+    """
+    Install a SIGTERM handler for the duration of the context that converts a
+    scheduler kill into a `SchedulerKilledError`, rather than letting the process
+    die with a confusing traceback part-way through a build.
+
+    Note that SIGKILL - which the scheduler sends if the process does not exit
+    promptly after SIGTERM - cannot be caught, so a hard kill will still
+    terminate the process abruptly.
+    """
+    msg = msg or (
+        "Terminated by SIGTERM: the job scheduler most likely killed this task. "
+        "If you are on a login node, run build-esm-datastore via ARE instead."
+    )
+
+    def _handler(signum: int, frame: FrameType | None) -> None:
+        raise SchedulerKilledError(msg)
+
+    previous = signal.getsignal(signal.SIGTERM)
+    signal.signal(signal.SIGTERM, _handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -3,6 +3,7 @@
 
 
 import shutil
+import warnings
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -17,11 +18,13 @@ from access_nri_intake.experiment.utils import (
     DatastoreInfo,
     DataStoreInvalidCause,
     DataStoreWarning,
+    LoginNodeWarning,
     MultipleDataStoreError,
     hash_catalog,
     parse_kwarg,
     validate_args,
     verify_ds_current,
+    warn_if_login_node,
 )
 from access_nri_intake.source import builders
 from access_nri_intake.source.builders import Builder
@@ -501,3 +504,20 @@ def test_parse_kwarg(kwarg, fails, expected):
     else:
         with pytest.raises(TypeError):
             parse_kwarg(kwarg)
+
+
+@pytest.mark.parametrize(
+    "mock_socket, warns",
+    [("gadi-login-08.gadi.nci.org.au", True), ("anything_else", False)],
+)
+def test_login_node_warning(mock_socket, warns):
+    """If we are running on a login node, assert a warning is raised about the
+    scheduler potentially killing the job"""
+    with mock.patch("socket.gethostname", return_value=mock_socket):
+        if warns:
+            with pytest.warns(LoginNodeWarning):
+                warn_if_login_node()
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", LoginNodeWarning)
+                warn_if_login_node()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -3,6 +3,8 @@
 
 
 import shutil
+import warnings
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -12,10 +14,12 @@ from intake_esm import esm_datastore
 from access_nri_intake.experiment.core import find_esm_datastore, use_datastore
 from access_nri_intake.experiment.utils import (
     DataStoreWarning,
+    LoginNodeWarning,
     MultipleDataStoreError,
     parse_kwarg,
     validate_args,
     verify_ds_current,
+    warn_if_login_node,
 )
 from access_nri_intake.source import builders
 from access_nri_intake.source.builders import Builder
@@ -305,3 +309,20 @@ def test_parse_kwarg(kwarg, fails, expected):
     else:
         with pytest.raises(TypeError):
             parse_kwarg(kwarg)
+
+
+@pytest.mark.parametrize(
+    "mock_socket, warns",
+    [("gadi-login-08.gadi.nci.org.au", True), ("anything_else", False)],
+)
+def test_login_node_warning(mock_socket, warns):
+    """If we are running on a login node, assert a warning is raised about the
+    scheduler potentially killing the job"""
+    with mock.patch("socket.gethostname", return_value=mock_socket):
+        if warns:
+            with pytest.warns(LoginNodeWarning):
+                warn_if_login_node()
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", LoginNodeWarning)
+                warn_if_login_node()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -4,8 +4,8 @@
 
 import shutil
 import warnings
-from datetime import datetime
 from pathlib import Path
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -16,6 +16,8 @@ from access_nri_intake.experiment.utils import (
     DataStoreWarning,
     LoginNodeWarning,
     MultipleDataStoreError,
+    SchedulerKilledError,
+    catch_scheduler_termination,
     parse_kwarg,
     validate_args,
     verify_ds_current,
@@ -326,3 +328,24 @@ def test_login_node_warning(mock_socket, warns):
             with warnings.catch_warnings():
                 warnings.simplefilter("error", LoginNodeWarning)
                 warn_if_login_node()
+
+
+def test_catch_scheduler_termination_raises_on_sigterm():
+    """A SIGTERM received inside the context should be converted into a
+    SchedulerKilledError rather than terminating the process."""
+    import os
+    import signal
+
+    with pytest.raises(SchedulerKilledError):
+        with catch_scheduler_termination():
+            os.kill(os.getpid(), signal.SIGTERM)
+
+
+def test_catch_scheduler_termination_restores_handler():
+    """The previous SIGTERM handler should be restored on exiting the context."""
+    import signal
+
+    original = signal.getsignal(signal.SIGTERM)
+    with catch_scheduler_termination():
+        assert signal.getsignal(signal.SIGTERM) is not original
+    assert signal.getsignal(signal.SIGTERM) is original


### PR DESCRIPTION
## Change Summary

Warn if we run the build datastore CLI from a login node. We might want to capture and reraise with this warning if the scheduler does kill the job too?


## Related issue number
See https://forum.access-hive.org.au/t/build-esm-datastore-failing-in-conda-analysis3-26-03/6245/21

 > Just to note, build-esm-datastore still fails (slowly, with prolific and scary-looking error messages) on a login node in conda/analysis3-26.04 through to conda/analysis3-26.07. But ARE works.
>
> Maybe it would be better for build-esm-datastore to simply abort with a message to use ARE if run on a login node?

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable