### PR TITLE
Bring all other builder parsers up to spec with ESM1.6 Builder, where relevant

### DIFF
--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -721,7 +721,7 @@ class AccessEsm15Builder(BaseBuilder):
         )
 
     @classmethod
-    def parser(cls, file, ensemble: bool = True) -> dict:
+    def parser(cls, file, ensemble: bool = False) -> dict:
         nc_info = cls.parse_ncfile(file)
         ncinfo_dict = nc_info.to_dict()
 

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -644,6 +644,9 @@ class Mom6Builder(BaseBuilder):
 class AccessEsm15Builder(BaseBuilder):
     """Intake-ESM datastore builder for ACCESS-ESM1.5 datasets"""
 
+    PATH_REGEX = r".*/(?P<exp_id>[^/]*)/history/(?P<realm>[^/]*)/.*\.nc"
+    REALM_MAPPING = {"atm": "atmos", "ocn": "ocean", "ice": "seaIce"}
+
     def __init__(self, path, ensemble: bool, **kwargs):
         """
         Initialise a AccessEsm15Builder
@@ -688,28 +691,34 @@ class AccessEsm15Builder(BaseBuilder):
             ]
             default_kwargs["groupby_attrs"] += ["member"]
 
-        default_kwargs["parsing_func_kwargs"] = {"ensemble": ensemble}
+            default_kwargs["parsing_func_kwargs"] = {"ensemble": ensemble}
 
         kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)
 
     @classmethod
-    def parser(cls, file, ensemble: bool = True) -> dict:
-        match = re.match(r".*/([^/]*)/history/([^/]*)/.*\.nc", file)
+    def _parse_regex(cls, file) -> tuple[str | None, str]:
+        """
+        Helper method to make testing easier.
+        """
+        match = re.match(cls.PATH_REGEX, file)
         if not match:
-            raise ParserError(
-                f"Unable to parse filepath {file} in {cls.__class__.__name__}"
-            )
+            raise ParserError(f"Unable to parse filepath {file} in {cls.__name__}")
 
-        exp_id = match.groups()[0]
-        realm = match.groups()[1]
+        match_dict = match.groupdict()
+        return (
+            match_dict.get("exp_id", None),
+            cls.REALM_MAPPING[match_dict["realm"]],
+        )
 
-        realm_mapping = {"atm": "atmos", "ocn": "ocean", "ice": "seaIce"}
-
+    @classmethod
+    def parser(cls, file, ensemble: bool = True) -> dict:
         nc_info = cls.parse_ncfile(file)
         ncinfo_dict = nc_info.to_dict()
 
-        ncinfo_dict["realm"] = realm_mapping[realm]
+        exp_id, realm = cls._parse_regex(file)
+
+        ncinfo_dict["realm"] = realm
         if ensemble:
             ncinfo_dict["member"] = exp_id
         ncinfo_dict["file_id"] = ".".join(

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -642,7 +642,16 @@ class Mom6Builder(BaseBuilder):
 
 
 class AccessEsm15Builder(BaseBuilder):
-    """Intake-ESM datastore builder for ACCESS-ESM1.5 datasets"""
+    """Intake-ESM datastore builder for ACCESS-ESM1.5 datasets
+
+    Path regex works as follows:
+
+    .*/                     Match any leading path, greedily, up to a slash.
+    (?P<exp_id>[^/]*)       Capture the next path component to the group 'exp_id'.
+    /history/               Match the literal '/history/' path component.
+    (?P<realm>[^/]*)        Capture the next path component to the group 'realm'.
+    /.*\.nc                 Match the remaining path ending in a .nc file.
+    """
 
     PATH_REGEX = r".*/(?P<exp_id>[^/]*)/history/(?P<realm>[^/]*)/.*\.nc"
     REALM_MAPPING = {"atm": "atmos", "ocn": "ocean", "ice": "seaIce"}

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -700,7 +700,7 @@ class AccessEsm15Builder(BaseBuilder):
             ]
             default_kwargs["groupby_attrs"] += ["member"]
 
-            default_kwargs["parsing_func_kwargs"] = {"ensemble": ensemble}
+        default_kwargs["parsing_func_kwargs"] = {"ensemble": ensemble}
 
         kwargs = {**default_kwargs, **kwargs}
         super().__init__(**kwargs)

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -720,7 +720,7 @@ class AccessEsm15Builder(BaseBuilder):
 
         ncinfo_dict["realm"] = realm
         if ensemble:
-            ncinfo_dict["member"] = exp_id
+            ncinfo_dict["member"] = exp_id  # type: ignore
         ncinfo_dict["file_id"] = ".".join(
             [
                 str(ncinfo_dict["realm"]),

--- a/src/access_nri_intake/source/builders.py
+++ b/src/access_nri_intake/source/builders.py
@@ -642,7 +642,7 @@ class Mom6Builder(BaseBuilder):
 
 
 class AccessEsm15Builder(BaseBuilder):
-    """Intake-ESM datastore builder for ACCESS-ESM1.5 datasets
+    r"""Intake-ESM datastore builder for ACCESS-ESM1.5 datasets
 
     Path regex works as follows:
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -472,6 +472,15 @@ def test_esm16_regex(test_path, expected):
 
     assert tup == expected, f"Expected {expected} but got {tup}"
 
+def test_esm15_regex_failure():
+    """
+    Assert that the regex parser for AccessEsm15Builder raises a ParserError when given a string that does not match the expected pattern.
+    """
+    with pytest.raises(builders.ParserError):
+        builders.AccessEsm15Builder._parse_regex(
+            "gobbledegook"
+        )
+
 
 def test_builder_columns_with_iterables(test_data):
     builder = builders.AccessOm2Builder(str(test_data / "access-om2"))

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -472,14 +472,13 @@ def test_esm16_regex(test_path, expected):
 
     assert tup == expected, f"Expected {expected} but got {tup}"
 
+
 def test_esm15_regex_failure():
     """
     Assert that the regex parser for AccessEsm15Builder raises a ParserError when given a string that does not match the expected pattern.
     """
     with pytest.raises(builders.ParserError):
-        builders.AccessEsm15Builder._parse_regex(
-            "gobbledegook"
-        )
+        builders.AccessEsm15Builder._parse_regex("gobbledegook")
 
 
 def test_builder_columns_with_iterables(test_data):


### PR DESCRIPTION
Closed #650, follows template of #649  