### PR TITLE
Add xxhash as an explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "polars>=1.24.0",
     "pooch",
     "xarray",
+    "xxhash>=3.7.0,<4",
     "colorama",
     "access-py-telemetry>=0.1.6",
     "wrapt>=2.1.2",


### PR DESCRIPTION
## Change Summary

Was implicitly a dependency of yamanifest & had gone missing.

## Related issue number

https://github.com/ACCESS-NRI/om3-scripts/pull/155#issuecomment-5312122688)
