### PR TITLE
Add ESM1.6 Datasets in `jq44`

### DIFF
--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -41,7 +41,7 @@ fi
 
 OUTPUT_BASE_PATH=/g/data/xp65/public/apps/access-nri-intake-catalog
 CONFIG_DIR=/g/data/xp65/admin/access-nri-intake-catalog/config
-CONFIGS=( cmip5.yaml cmip6.yaml access-om2.yaml access-cm2.yaml access-esm1-5.yaml ccam.yaml barpa.yaml barra2.yaml cordex.yaml mom6.yaml narclim2.yaml era5.yaml romsiceshelf.yaml esgf-ref.yaml esmvaltool-obs.yaml woa.yaml aus2200.yaml online-mlt.yaml )
+CONFIGS=( cmip5.yaml cmip6.yaml access-om2.yaml access-cm2.yaml access-esm1-5.yaml access-esm1-6.yaml ccam.yaml barpa.yaml barra2.yaml cordex.yaml mom6.yaml narclim2.yaml era5.yaml romsiceshelf.yaml esgf-ref.yaml esmvaltool-obs.yaml woa.yaml aus2200.yaml online-mlt.yaml )
 
 config_paths=( "${CONFIGS[@]/#/${CONFIG_DIR}/}" )
 

--- a/bin/build_all.sh
+++ b/bin/build_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 #PBS -P iq82
-#PBS -l storage=gdata/xp65+gdata/ik11+gdata/cj50+gdata/p73+gdata/dk92+gdata/al33+gdata/rr3+gdata/fs38+gdata/oi10+gdata/hq89+gdata/py18+gdata/ig45+gdata/zz63+gdata/rt52+gdata/jk72+gdata/qv56+gdata/ct11+gdata/ol01+gdata/bs94+gdata/av17+gdata/ob53
+#PBS -l storage=gdata/xp65+gdata/ik11+gdata/cj50+gdata/p73+gdata/dk92+gdata/al33+gdata/rr3+gdata/fs38+gdata/oi10+gdata/hq89+gdata/py18+gdata/ig45+gdata/zz63+gdata/rt52+gdata/jk72+gdata/qv56+gdata/ct11+gdata/ol01+gdata/bs94+gdata/av17+gdata/ob53+gdata/jq44
 #PBS -q normal
 #PBS -W block=false
 #PBS -l walltime=06:00:00

--- a/config/access-esm1-6.yaml
+++ b/config/access-esm1-6.yaml
@@ -1,0 +1,40 @@
+builder: AccessEsm16Builder
+
+translator: DefaultTranslator
+
+sources:
+
+  - metadata_yaml: /g/data/jq44/access-nri/access-esm1p6/global/1pctCO2/r1i1p1f1/2026.04.15/metadata.yaml
+    ensemble: false
+    path:
+      - /g/data/jq44/access-nri/access-esm1p6/global/1pctCO2/r1i1p1f1/2026.04.15
+    
+  - metadata_yaml: /g/data/jq44/access-nri/access-esm1p6/global/esm-historical/r1i1p1f1/2026.06.12/metadata.yaml
+    # Currently only one ensemble member has been published
+    # May need a shared metadata.yaml when other members are ready?
+    ensemble: true
+    path:
+      - /g/data/jq44/access-nri/access-esm1p6/global/esm-historical/r1i1p1f1/2026.06.12
+
+  - metadata_yaml: /g/data/jq44/access-nri/access-esm1p6/global/esm-piControl/r1i1p1f1/2026.04.14/metadata.yaml
+    ensemble: false
+    path:
+      - /g/data/jq44/access-nri/access-esm1p6/global/esm-piControl/r1i1p1f1/2026.04.14
+
+  - metadata_yaml: /g/data/jq44/access-nri/access-esm1p6/global/historical/r1i1p1f1/2026.06.12/metadata.yaml
+    # Currently only one ensemble member has been published
+    # May need a shared metadata.yaml when other members are ready?
+    ensemble: true
+    path:
+      - /g/data/jq44/access-nri/access-esm1p6/global/historical/r1i1p1f1/2026.06.12
+    
+
+  - metadata_yaml: /g/data/jq44/access-nri/access-esm1p6/global/piControl/r1i1p1f1/2026.04.07/metadata.yaml
+    ensemble: false
+    path:
+      - /g/data/jq44/access-nri/access-esm1p6/global/piControl/r1i1p1f1/2026.04.07
+
+  - metadata_yaml: /g/data/jq44/access-nri/access-esm1p6/global/piControl/r1i1p1f1/2026.04.22/metadata.yaml
+    ensemble: false
+    path:
+      - /g/data/jq44/access-nri/access-esm1p6/global/piControl/r1i1p1f1/2026.04.22


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Adds 6 new ESM1.6 datasets in `jq44` to catalogue

## Related issue number

Closes #666 

## Checklist

<!-- Delete this section unless you have added a new translator/datastore: -->
-  [x] The new datastore has been added to the list of configs in `bin/build_all.sh` and `bin/test_end_to_end.sh`, and the storage flags in both scripts updated, if necessary.
- [x] You have generated a valid `metadata.yaml` for the datastore & placed it in the correct location: eg. `config/metadata_sources/esgf-ref-qv56/metadata.yaml` for the `esgf-ref-qv56` datastore.
    - `metadata.yaml` located with data
- [x] The `metadata.yaml` has been copied to the correct location in `/g/data/xp65/admin/intake` -  for example, `/g/data/xp65/admin/intake/metadata/esgf-ref-qv56/metadata.yaml` for the `esgf-ref-qv56` datastore
    - `metadata.yaml` located with data

## Notes

- In order to build a new catalog including this additional datastore, you will need to either release a new version of the `access-nri-intake` package, or run the `bin/build_all.sh` script to build a new catalog, using a virtual environment with the most recent (ie. including this PR) version of `access-nri-intake` installed. This can be done by activating the `venv` in `/g/data/xp65/admin/access-nri-intake-catalog/bin/build_all.sh` job.
<!-- End of Translator Change section  -->

<!--
Please add any other relevant info below:
-->